### PR TITLE
add markdown table support for LLM rendering

### DIFF
--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -107,6 +107,13 @@ const NonMemoizedMarkdown = ({ children, headingClassName, asSpan }: Props) => {
         code({ className, children }) {
           const match = /language-(\w+)/.exec(className ?? "");
 
+          if (match?.[1] === "markdown") {
+            // Markdown in code blocks is an LLM oopsie, so we need to escape the codeblock
+            return (
+              <NonMemoizedMarkdown>{children as string}</NonMemoizedMarkdown>
+            );
+          }
+
           if (!match) {
             return (
               <code
@@ -164,6 +171,50 @@ const NonMemoizedMarkdown = ({ children, headingClassName, asSpan }: Props) => {
         pre({ children }) {
           return (
             <div className="w-full max-w-full overflow-hidden">{children}</div>
+          );
+        },
+        table({ children }) {
+          return (
+            <div className="my-4 w-full overflow-x-auto">
+              <table className="w-full border-collapse border border-border text-sm">
+                {children}
+              </table>
+            </div>
+          );
+        },
+        thead({ children }) {
+          return (
+            <thead className="bg-muted/50">
+              {children}
+            </thead>
+          );
+        },
+        tbody({ children }) {
+          return (
+            <tbody>
+              {children}
+            </tbody>
+          );
+        },
+        tr({ children }) {
+          return (
+            <tr className="border-b border-border hover:bg-muted/25 transition-colors">
+              {children}
+            </tr>
+          );
+        },
+        th({ children }) {
+          return (
+            <th className="border border-border px-3 py-2 text-left font-semibold">
+              {children}
+            </th>
+          );
+        },
+        td({ children }) {
+          return (
+            <td className="border border-border px-3 py-2">
+              {children}
+            </td>
           );
         },
       }}


### PR DESCRIPTION
Add Markdown table support for LLM rendering. 

Uses React-Markdown, and takes advantage of a recursive component render in the case of the LLM spitting out markdown in a code block. 