### PR TITLE
PWA install button

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # When adding additional environment variables, the schema in "/src/env.js"
 # should be updated accordingly.
 
-APP_URL="http://localhost:3000"
+NEXTAUTH_URL="http://localhost:3000"
 
 # Next Auth
 # You can generate a new secret on the command line with:

--- a/src/app/_components/sidebar/index.tsx
+++ b/src/app/_components/sidebar/index.tsx
@@ -20,6 +20,7 @@ import Link from "next/link";
 import { HStack, VStack } from "@/components/ui/stack";
 import { SiGithub } from "@icons-pack/react-simple-icons";
 import { WorkbenchSelect } from "./workbench-select";
+import { InstallPrompt } from "./install-prompt";
 
 export async function AppSidebar({
   ...props
@@ -60,6 +61,9 @@ export async function AppSidebar({
           <NavChats />
         </SidebarContent>
         <SidebarFooter className="flex flex-col gap-2 p-3 group-data-[collapsible=icon]:p-2">
+          <div className="group-data-[collapsible=icon]:hidden">
+            <InstallPrompt />
+          </div>
           <SidebarMenuButton
             asChild
             className="hover:bg-sidebar-accent/50 h-fit w-full rounded-lg p-2 transition-colors group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2"

--- a/src/app/_components/sidebar/install-prompt.tsx
+++ b/src/app/_components/sidebar/install-prompt.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useInstallPrompt } from "@/contexts/install-prompt-context";
+import { Download, X } from "lucide-react";
+
+export function InstallPrompt() {
+  const {
+    installPrompt,
+    isIOS,
+    isStandalone,
+    isDismissed,
+    handleInstall,
+    dismissPrompt,
+  } = useInstallPrompt();
+
+  if (isStandalone || isDismissed) {
+    return null; // Don't show if already installed or dismissed
+  }
+
+  // Only show if we have an install prompt OR if it's iOS
+  if (!installPrompt && !isIOS) {
+    return null;
+  }
+
+  return (
+    <div className="bg-card relative flex flex-col gap-3 rounded-lg border p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="font-semibold">Install Toolkit.dev</h3>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={dismissPrompt}
+          className="text-muted-foreground hover:text-foreground h-6 w-6 p-0 hover:bg-transparent"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {installPrompt ? (
+        <div className="space-y-3">
+          <p className="text-muted-foreground text-sm">
+            Install Toolkit.dev for quick access and a better experience.
+          </p>
+          <Button onClick={handleInstall} className="w-full">
+            <Download className="mr-2 h-4 w-4" />
+            Install App
+          </Button>
+        </div>
+      ) : isIOS ? (
+        <p className="text-muted-foreground text-sm">
+          To install this app on your iOS device, tap the share button ⎋ and
+          then &ldquo;Add to Home Screen&rdquo; ➕.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/_components/sidebar/install-prompt.tsx
+++ b/src/app/_components/sidebar/install-prompt.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useInstallPrompt } from "@/contexts/install-prompt-context";
-import { Download, X } from "lucide-react";
+import { Download, Plus, Share, X } from "lucide-react";
 
 export function InstallPrompt() {
   const {
@@ -42,7 +42,7 @@ export function InstallPrompt() {
       {installPrompt ? (
         <div className="space-y-3">
           <p className="text-muted-foreground text-sm">
-            Install Toolkit.dev for quick access and a better experience.
+            Install Toolkit.dev for quick access
           </p>
           <Button onClick={handleInstall} className="w-full">
             <Download className="mr-2 h-4 w-4" />
@@ -51,8 +51,15 @@ export function InstallPrompt() {
         </div>
       ) : isIOS ? (
         <p className="text-muted-foreground text-sm">
-          To install this app on your iOS device, tap the share button ⎋ and
-          then &ldquo;Add to Home Screen&rdquo; ➕.
+          To install this app on your iOS device, tap the share button{" "}
+          <span className="inline-block align-middle leading-none">
+            <Share className="inline h-4 w-4" />
+          </span>{" "}
+          and then <span className="font-semibold">Add to Home Screen</span>{" "}
+          <span className="inline-block align-middle leading-none">
+            <Plus className="inline h-4 w-4" />
+          </span>
+          .
         </p>
       ) : null}
     </div>

--- a/src/app/_components/sidebar/install-prompt.tsx
+++ b/src/app/_components/sidebar/install-prompt.tsx
@@ -42,7 +42,7 @@ export function InstallPrompt() {
       {installPrompt ? (
         <div className="space-y-3">
           <p className="text-muted-foreground text-sm">
-            Install Toolkit.dev for quick access
+            Install Toolkit.dev to your home screen for quick access.
           </p>
           <Button onClick={handleInstall} className="w-full">
             <Download className="mr-2 h-4 w-4" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { TRPCReactProvider } from "@/trpc/react";
 
 import { Toaster } from "@/components/ui/sonner";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { InstallPromptProvider } from "@/contexts/install-prompt-context";
 
 import { AppSidebar } from "./_components/sidebar";
 import { Navbar } from "./_components/navbar";
@@ -55,6 +56,20 @@ export default async function RootLayout({
     >
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link
+          rel="apple-touch-icon"
+          sizes="192x192"
+          href="/manifest/web-app-manifest-192x192.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="512x512"
+          href="/manifest/web-app-manifest-512x512.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          href="/manifest/web-app-manifest-192x192.png"
+        />
       </head>
       <body>
         <Analytics />
@@ -66,13 +81,15 @@ export default async function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
-            <SidebarProvider>
-              <AppSidebar />
-              <SidebarInset className="flex h-dvh flex-col">
-                <Navbar />
-                {children}
-              </SidebarInset>
-            </SidebarProvider>
+            <InstallPromptProvider>
+              <SidebarProvider>
+                <AppSidebar />
+                <SidebarInset className="flex h-dvh flex-col">
+                  <Navbar />
+                  {children}
+                </SidebarInset>
+              </SidebarProvider>
+            </InstallPromptProvider>
           </ThemeProvider>
         </TRPCReactProvider>
         <Toaster />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,20 +56,6 @@ export default async function RootLayout({
     >
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link
-          rel="apple-touch-icon"
-          sizes="192x192"
-          href="/manifest/web-app-manifest-192x192.png"
-        />
-        <link
-          rel="apple-touch-icon"
-          sizes="512x512"
-          href="/manifest/web-app-manifest-512x512.png"
-        />
-        <link
-          rel="apple-touch-icon"
-          href="/manifest/web-app-manifest-192x192.png"
-        />
       </head>
       <body>
         <Analytics />

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -176,46 +176,34 @@ const NonMemoizedMarkdown = ({ children, headingClassName, asSpan }: Props) => {
         table({ children }) {
           return (
             <div className="my-4 w-full overflow-x-auto">
-              <table className="w-full border-collapse border border-border text-sm">
+              <table className="border-border w-full border-collapse border text-sm">
                 {children}
               </table>
             </div>
           );
         },
         thead({ children }) {
-          return (
-            <thead className="bg-muted/50">
-              {children}
-            </thead>
-          );
+          return <thead className="bg-muted/50">{children}</thead>;
         },
         tbody({ children }) {
-          return (
-            <tbody>
-              {children}
-            </tbody>
-          );
+          return <tbody>{children}</tbody>;
         },
         tr({ children }) {
           return (
-            <tr className="border-b border-border hover:bg-muted/25 transition-colors">
+            <tr className="border-border hover:bg-muted/25 border-b transition-colors">
               {children}
             </tr>
           );
         },
         th({ children }) {
           return (
-            <th className="border border-border px-3 py-2 text-left font-semibold">
+            <th className="border-border border px-3 py-2 text-left font-semibold">
               {children}
             </th>
           );
         },
         td({ children }) {
-          return (
-            <td className="border border-border px-3 py-2">
-              {children}
-            </td>
-          );
+          return <td className="border-border border px-3 py-2">{children}</td>;
         },
       }}
     >

--- a/src/contexts/install-prompt-context.tsx
+++ b/src/contexts/install-prompt-context.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+interface InstallPromptContextType {
+  installPrompt: BeforeInstallPromptEvent | null;
+  isIOS: boolean;
+  isStandalone: boolean;
+  isDismissed: boolean;
+  handleInstall: () => Promise<void>;
+  dismissPrompt: () => void;
+}
+
+interface Window {
+  MSStream: unknown;
+}
+
+const InstallPromptContext = createContext<InstallPromptContextType | null>(
+  null,
+);
+
+// Global capture BEFORE React hydration
+let globalPrompt: BeforeInstallPromptEvent | null = null;
+let isListenerSetup = false;
+
+// Set up listener immediately when module loads (before React hydration)
+if (typeof window !== "undefined" && !isListenerSetup) {
+  isListenerSetup = true;
+
+  window.addEventListener("beforeinstallprompt", (e: Event) => {
+    e.preventDefault();
+    globalPrompt = e as BeforeInstallPromptEvent;
+  });
+}
+
+// Why is this a provider?
+// The main events that we are looking for to detect the state of the pwa installations
+// is beforeinstallprompt which fires once and only once when the app mounts, this means if
+// we have the prompt inside of a conditionally rendered component, it will not be listening
+// when the event fires so cannot detect the state of the pwa installation.
+export function InstallPromptProvider({ children }: { children: ReactNode }) {
+  const [installPrompt, setInstallPrompt] =
+    useState<BeforeInstallPromptEvent | null>(globalPrompt);
+  const [isIOS, setIsIOS] = useState(false);
+  const [isStandalone, setIsStandalone] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  useEffect(() => {
+    // Set up device detection
+    setIsIOS(
+      /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+        !(window as unknown as Window).MSStream,
+    );
+
+    setIsStandalone(window.matchMedia("(display-mode: standalone)").matches);
+
+    // Check if user has dismissed the prompt
+    const dismissed = localStorage.getItem("installPromptDismissed") === "true";
+    setIsDismissed(dismissed);
+
+    // Check if we already captured the prompt before React hydrated
+    if (globalPrompt && !installPrompt) {
+      setInstallPrompt(globalPrompt);
+    }
+
+    // Set up listener for future events (in case it fires again)
+    const handleBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault();
+      const prompt = e as BeforeInstallPromptEvent;
+      globalPrompt = prompt;
+      setInstallPrompt(prompt);
+    };
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+
+    return () => {
+      window.removeEventListener(
+        "beforeinstallprompt",
+        handleBeforeInstallPrompt,
+      );
+    };
+  }, [installPrompt]);
+
+  const handleInstall = async () => {
+    if (!installPrompt) return;
+
+    try {
+      await installPrompt.prompt();
+      const { outcome } = await installPrompt.userChoice;
+
+      if (outcome === "accepted") {
+        globalPrompt = null;
+        setInstallPrompt(null);
+      }
+    } catch (error) {
+      console.error("Install prompt error:", error);
+    }
+  };
+
+  const dismissPrompt = () => {
+    localStorage.setItem("installPromptDismissed", "true");
+    setIsDismissed(true);
+  };
+
+  return (
+    <InstallPromptContext.Provider
+      value={{
+        installPrompt,
+        isIOS,
+        isStandalone,
+        isDismissed,
+        handleInstall,
+        dismissPrompt,
+      }}
+    >
+      {children}
+    </InstallPromptContext.Provider>
+  );
+}
+
+export function useInstallPrompt() {
+  const context = useContext(InstallPromptContext);
+  if (!context) {
+    throw new Error(
+      "useInstallPrompt must be used within InstallPromptProvider",
+    );
+  }
+  return context;
+}

--- a/src/env.js
+++ b/src/env.js
@@ -106,7 +106,7 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
-    APP_URL: z.string().url(),
+    NEXTAUTH_URL: z.string().url(),
     AUTH_SECRET:
       process.env.NODE_ENV === "production"
         ? z.string()
@@ -139,7 +139,7 @@ export const env = createEnv({
    * middlewares) or client-side so we need to destruct manually.
    */
   runtimeEnv: {
-    APP_URL: process.env.APP_URL,
+    NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     AUTH_SECRET: process.env.AUTH_SECRET,
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,

--- a/src/server/auth/providers.ts
+++ b/src/server/auth/providers.ts
@@ -60,7 +60,7 @@ export const providers: (
         NotionProvider({
           clientId: env.AUTH_NOTION_ID,
           clientSecret: env.AUTH_NOTION_SECRET,
-          redirectUri: `${env.APP_URL}/api/auth/callback/notion`,
+          redirectUri: `${env.NEXTAUTH_URL}/api/auth/callback/notion`,
         }),
       ]
     : []),


### PR DESCRIPTION
Add a convenience CTA to install toolkit as a PWA. Unfortunately, links to install do not work on iOS.  
<img width="386" height="277" alt="image" src="https://github.com/user-attachments/assets/29efefe4-d0a7-410c-98b0-64ab922e48bb" />

--- 
Other nits while im in here

- APP_URL -> NEXTAUTH_URL (this avoids login redirect weirdness confusion)
- fmt in the md 


