### PR TITLE
Handle stream errors in the chat

### DIFF
--- a/src/app/_components/chat/messages/index.tsx
+++ b/src/app/_components/chat/messages/index.tsx
@@ -75,15 +75,16 @@ const PureMessages: React.FC<Props> = ({
           />
         ))}
 
-      {!streamStopped && ((status === "submitted" &&
-        messages.length > 0 &&
-        lastMessage?.role === "user") ||
-        (lastMessage?.role === "assistant" &&
-          (lastMessage?.parts?.length === 0 ||
-            (lastMessage?.parts?.length === 1 &&
-              lastMessage?.parts?.[0]?.type === "step-start")))) && (
-        <ThinkingMessage />
-      )}
+      {!streamStopped &&
+        ((status === "submitted" &&
+          messages.length > 0 &&
+          lastMessage?.role === "user") ||
+          (lastMessage?.role === "assistant" &&
+            (lastMessage?.parts?.length === 0 ||
+              (lastMessage?.parts?.length === 1 &&
+                lastMessage?.parts?.[0]?.type === "step-start")))) && (
+          <ThinkingMessage />
+        )}
 
       <motion.div
         ref={endRef}

--- a/src/app/_components/chat/messages/index.tsx
+++ b/src/app/_components/chat/messages/index.tsx
@@ -25,7 +25,7 @@ const PureMessages: React.FC<Props> = ({
   onViewportLeave,
   scrollToBottom,
 }) => {
-  const { messages, status } = useChatContext();
+  const { messages, status, streamStopped } = useChatContext();
 
   const { hasSentMessage } = useMessages({
     chatId,
@@ -75,7 +75,7 @@ const PureMessages: React.FC<Props> = ({
           />
         ))}
 
-      {((status === "submitted" &&
+      {!streamStopped && ((status === "submitted" &&
         messages.length > 0 &&
         lastMessage?.role === "user") ||
         (lastMessage?.role === "assistant" &&

--- a/src/app/_contexts/chat-context.tsx
+++ b/src/app/_contexts/chat-context.tsx
@@ -270,7 +270,10 @@ export function ChatProvider({
     },
   });
 
-  const handleSubmit: UseChatHelpers["handleSubmit"] = (event, chatRequestOptions) => {
+  const handleSubmit: UseChatHelpers["handleSubmit"] = (
+    event,
+    chatRequestOptions,
+  ) => {
     // Reset stream stopped flag when submitting new message
     setStreamStopped(false);
     originalHandleSubmit(event, chatRequestOptions);

--- a/src/app/_contexts/chat-context.tsx
+++ b/src/app/_contexts/chat-context.tsx
@@ -41,6 +41,7 @@ interface ChatContextType {
   input: string;
   setInput: UseChatHelpers["setInput"];
   status: UseChatHelpers["status"];
+  streamStopped: boolean;
   attachments: Array<Attachment>;
   setAttachments: (
     attachments:
@@ -165,6 +166,7 @@ export function ChatProvider({
     return [];
   });
   const [hasInvalidated, setHasInvalidated] = useState(false);
+  const [streamStopped, setStreamStopped] = useState(false);
 
   // Wrapper functions that also save to cookies
   const setSelectedChatModel = (model: LanguageModel) => {
@@ -198,7 +200,7 @@ export function ChatProvider({
   const {
     messages,
     setMessages,
-    handleSubmit,
+    handleSubmit: originalHandleSubmit,
     input,
     setInput,
     append,
@@ -235,6 +237,7 @@ export function ChatProvider({
       workbenchId: workbench?.id,
     }),
     onFinish: () => {
+      setStreamStopped(false);
       void utils.messages.getMessagesForChat.invalidate({ chatId: id });
       if (initialMessages.length === 0 && !hasInvalidated) {
         setHasInvalidated(true);
@@ -259,7 +262,19 @@ export function ChatProvider({
     experimental_resume,
     data,
     setMessages,
+    onStreamError: () => {
+      // Mark stream as stopped to hide thinking message
+      setStreamStopped(true);
+      // Also call stop to change the status away from 'submitted'
+      stop();
+    },
   });
+
+  const handleSubmit: UseChatHelpers["handleSubmit"] = (event, chatRequestOptions) => {
+    // Reset stream stopped flag when submitting new message
+    setStreamStopped(false);
+    originalHandleSubmit(event, chatRequestOptions);
+  };
 
   useEffect(() => {
     if (
@@ -279,6 +294,7 @@ export function ChatProvider({
     input,
     setInput,
     status,
+    streamStopped,
     attachments,
     setAttachments,
     selectedChatModel,

--- a/src/app/_contexts/chat-context.tsx
+++ b/src/app/_contexts/chat-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState, useCallback } from "react";
 
 import { useChat } from "@ai-sdk/react";
 
@@ -256,18 +256,20 @@ export function ChatProvider({
     },
   });
 
+  const onStreamError = useCallback(() => {
+    // Mark stream as stopped to hide thinking message
+    setStreamStopped(true);
+    // Also call stop to change the status away from 'submitted'
+    stop();
+  }, [stop]);
+
   useAutoResume({
     autoResume,
     initialMessages,
     experimental_resume,
     data,
     setMessages,
-    onStreamError: () => {
-      // Mark stream as stopped to hide thinking message
-      setStreamStopped(true);
-      // Also call stop to change the status away from 'submitted'
-      stop();
-    },
+    onStreamError,
   });
 
   const handleSubmit: UseChatHelpers["handleSubmit"] = (

--- a/src/app/_hooks/use-auto-resume.tsx
+++ b/src/app/_hooks/use-auto-resume.tsx
@@ -53,5 +53,5 @@ export function useAutoResume({
       toast.error(dataPart.message);
       onStreamError?.();
     }
-  }, [data, initialMessages, setMessages]);
+  }, [data, initialMessages, setMessages, onStreamError]);
 }

--- a/src/app/_hooks/use-auto-resume.tsx
+++ b/src/app/_hooks/use-auto-resume.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useEffect } from "react";
+import { toast } from "sonner";
 
 import type { UIMessage } from "ai";
 import type { UseChatHelpers } from "@ai-sdk/react";
 
-type DataPart = { type: "append-message"; message: string };
+type DataPart =
+  | { type: "append-message"; message: string }
+  | { type: "error"; message: string };
 
 export interface UseAutoResumeParams {
   autoResume: boolean;
@@ -13,6 +16,7 @@ export interface UseAutoResumeParams {
   experimental_resume: UseChatHelpers["experimental_resume"];
   data: UseChatHelpers["data"];
   setMessages: UseChatHelpers["setMessages"];
+  onStreamError?: () => void;
 }
 
 export function useAutoResume({
@@ -21,6 +25,7 @@ export function useAutoResume({
   experimental_resume,
   data,
   setMessages,
+  onStreamError,
 }: UseAutoResumeParams) {
   useEffect(() => {
     if (!autoResume) return;
@@ -44,6 +49,9 @@ export function useAutoResume({
     if (dataPart.type === "append-message") {
       const message = JSON.parse(dataPart.message) as UIMessage;
       setMessages([...initialMessages, message]);
+    } else if (dataPart.type === "error") {
+      toast.error(dataPart.message);
+      onStreamError?.();
     }
   }, [data, initialMessages, setMessages]);
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -255,21 +255,26 @@ export async function POST(request: Request) {
             experimental_generateMessageId: generateUUID,
             onError: (error) => {
               console.error("Stream error occurred:", error);
-              
+
               // Check if it's a 402 error and log it specifically
-              if (error && typeof error === 'object') {
+              if (error && typeof error === "object") {
                 const errorStr = JSON.stringify(error);
-                if (errorStr.includes('402') || errorStr.includes('requires more credits')) {
-                  console.error("OpenRouter credits exhausted - 402 error detected");
+                if (
+                  errorStr.includes("402") ||
+                  errorStr.includes("requires more credits")
+                ) {
+                  console.error(
+                    "OpenRouter credits exhausted - 402 error detected",
+                  );
                 }
               }
-              
+
               // Send error to frontend - this will trigger onStreamError which calls stop()
               dataStream.writeData({
-                type: 'error',
-                message: 'An error occurred while processing your request',
+                type: "error",
+                message: "An error occurred while processing your request",
               });
-              
+
               // Don't throw - just let the stream end naturally after sending error data
             },
             onFinish: async ({ response }) => {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -254,8 +254,23 @@ export async function POST(request: Request) {
             experimental_transform: smoothStream({ chunking: "word" }),
             experimental_generateMessageId: generateUUID,
             onError: (error) => {
-              console.error(error);
-              throw new ChatSDKError("bad_request:api");
+              console.error("Stream error occurred:", error);
+              
+              // Check if it's a 402 error and log it specifically
+              if (error && typeof error === 'object') {
+                const errorStr = JSON.stringify(error);
+                if (errorStr.includes('402') || errorStr.includes('requires more credits')) {
+                  console.error("OpenRouter credits exhausted - 402 error detected");
+                }
+              }
+              
+              // Send error to frontend - this will trigger onStreamError which calls stop()
+              dataStream.writeData({
+                type: 'error',
+                message: 'An error occurred while processing your request',
+              });
+              
+              // Don't throw - just let the stream end naturally after sending error data
             },
             onFinish: async ({ response }) => {
               const model = languageModels.find(
@@ -335,7 +350,7 @@ export async function POST(request: Request) {
         });
       },
       onError: (error) => {
-        console.error(error);
+        console.error("Data stream error:", error);
         throw new ChatSDKError("bad_request:api");
       },
     });

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -176,46 +176,34 @@ const NonMemoizedMarkdown = ({ children, headingClassName, asSpan }: Props) => {
         table({ children }) {
           return (
             <div className="my-4 w-full overflow-x-auto">
-              <table className="w-full border-collapse border border-border text-sm">
+              <table className="border-border w-full border-collapse border text-sm">
                 {children}
               </table>
             </div>
           );
         },
         thead({ children }) {
-          return (
-            <thead className="bg-muted/50">
-              {children}
-            </thead>
-          );
+          return <thead className="bg-muted/50">{children}</thead>;
         },
         tbody({ children }) {
-          return (
-            <tbody>
-              {children}
-            </tbody>
-          );
+          return <tbody>{children}</tbody>;
         },
         tr({ children }) {
           return (
-            <tr className="border-b border-border hover:bg-muted/25 transition-colors">
+            <tr className="border-border hover:bg-muted/25 border-b transition-colors">
               {children}
             </tr>
           );
         },
         th({ children }) {
           return (
-            <th className="border border-border px-3 py-2 text-left font-semibold">
+            <th className="border-border border px-3 py-2 text-left font-semibold">
               {children}
             </th>
           );
         },
         td({ children }) {
-          return (
-            <td className="border border-border px-3 py-2">
-              {children}
-            </td>
-          );
+          return <td className="border-border border px-3 py-2">{children}</td>;
         },
       }}
     >


### PR DESCRIPTION
Need to handle internal errors from the be on the streaming chat. Whenever an error is hit on the be, send type error over the stream and close the stream.  

<img width="1742" height="823" alt="image" src="https://github.com/user-attachments/assets/be7059f0-5d55-4fc1-b77d-4d4dbfd6b5b1" />


decided not to propagate the 402 here because its totally an internal error. If the billing was being passed through to the user, then that may make sense :bat: