### PR TITLE
Update the toolkit select UI to be a command with search

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "ai": "^4.3.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "cookies-next": "^6.0.0",
     "date-fns": "^4.1.0",
     "exa-js": "^1.8.8",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-portal": "^1.1.9",
+    "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slider": "^1.3.5",
     "@radix-ui/react-slot": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       cookies-next:
         specifier: ^6.0.0
         version: 6.0.0(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
@@ -2503,6 +2506,12 @@ packages:
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -7671,6 +7680,18 @@ snapshots:
   clsx@2.1.1: {}
 
   cluster-key-slot@1.1.2: {}
+
+  cmdk@1.1.1(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   color-convert@2.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@radix-ui/react-portal':
         specifier: ^1.1.9
         version: 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.2.9
+        version: 1.2.9(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-separator':
         specifier: ^1.1.7
         version: 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1382,6 +1385,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.10':
     resolution: {integrity: sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.9':
+    resolution: {integrity: sha512-YSjEfBXnhUELsO2VzjdtYYD4CfQjvao+lhhrX5XsHD7/cyUNzljF1FHEbgTPN7LH2MClfwRMIsYlqTYpKTTe2A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6523,6 +6539,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.6)(react@19.1.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.6)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.6
+      '@types/react-dom': 19.1.6(@types/react@19.1.6)
+
+  '@radix-ui/react-scroll-area@1.2.9(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.6)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:

--- a/src/app/_components/chat/input/tools.tsx
+++ b/src/app/_components/chat/input/tools.tsx
@@ -32,13 +32,9 @@ import { LanguageModelCapability } from "@/ai/types";
 
 import { cn } from "@/lib/utils";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
   Drawer,
   DrawerContent,
+  DrawerDescription,
   DrawerHeader,
   DrawerTitle,
   DrawerTrigger,
@@ -47,7 +43,6 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import type { SelectedToolkit } from "@/components/toolkit/types";
 import type { Workbench } from "@prisma/client";
 import type { Toolkits } from "@/toolkits/toolkits/shared";
-import { VStack } from "@/components/ui/stack";
 
 // Shared content component for both dropdown and drawer
 const ToolkitSelectContent: React.FC<{
@@ -65,53 +60,27 @@ const ToolkitSelectContent: React.FC<{
   workbench,
   handleSave,
   isPending,
-  isMobile = false,
 }) => (
-  <>
-    <div
-      className={cn(
-        "bg-background border-b",
-        isMobile ? "p-4" : "sticky top-0 z-10 p-2",
-      )}
-    >
-      <h2 className={cn("mb-1 font-bold", isMobile ? "text-lg" : "text-sm")}>
-        Toolkit Selector
-      </h2>
-      <div
-        className={cn(
-          "text-muted-foreground",
-          isMobile ? "text-base" : "text-sm",
-        )}
-      >
-        Add or remove tools to enhance your chat experience
+  <div className={cn("w-full max-w-full")}>
+    <ToolkitList
+      selectedToolkits={toolkits}
+      onAddToolkit={addToolkit}
+      onRemoveToolkit={removeToolkit}
+    />
+    {workbench !== undefined && (
+      <div className="border-t p-2">
+        <Button
+          variant={"outline"}
+          className="w-full bg-transparent"
+          onClick={handleSave}
+          disabled={isPending}
+        >
+          {isPending ? <Loader2 className="animate-spin" /> : <Save />}
+          Save
+        </Button>
       </div>
-    </div>
-    <div
-      className={cn(
-        "w-full max-w-full overflow-x-hidden overflow-y-auto px-2 py-2",
-        isMobile ? "max-h-[50vh] pb-4" : "max-h-56 pr-1 pl-2 md:max-h-80",
-      )}
-    >
-      <ToolkitList
-        selectedToolkits={toolkits}
-        onAddToolkit={addToolkit}
-        onRemoveToolkit={removeToolkit}
-      />
-      {workbench !== undefined && (
-        <div className="border-t p-2">
-          <Button
-            variant={"outline"}
-            className="w-full bg-transparent"
-            onClick={handleSave}
-            disabled={isPending}
-          >
-            {isPending ? <Loader2 className="animate-spin" /> : <Save />}
-            Save
-          </Button>
-        </div>
-      )}
-    </div>
-  </>
+    )}
+  </div>
 );
 
 export const ToolsSelect = () => {
@@ -221,9 +190,12 @@ export const ToolsSelect = () => {
       {isMobile ? (
         <Drawer open={isOpen} onOpenChange={setIsOpen}>
           <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
-          <DrawerContent>
-            <DrawerHeader className="sr-only">
+          <DrawerContent className="p-0">
+            <DrawerHeader className="items-start">
               <DrawerTitle>Toolkit Selector</DrawerTitle>
+              <DrawerDescription>
+                Add tools to give the model more capabilities
+              </DrawerDescription>
             </DrawerHeader>
             <ToolkitSelectContent {...contentProps} isMobile={true} />
           </DrawerContent>
@@ -237,20 +209,12 @@ export const ToolsSelect = () => {
             align="start"
             sideOffset={8}
           >
-            <div className="flex h-full max-h-full flex-col overflow-hidden">
-              <VStack className="items-start gap-0 p-2 pb-0">
-                <h2 className="mb-1 font-bold">Toolkit Selector</h2>
-                <p className="text-muted-foreground text-sm">
-                  Add or remove tools to augment your chat experience
-                </p>
-              </VStack>
-              <div className="h-0 flex-1 overflow-hidden">
-                <ToolkitList
-                  selectedToolkits={toolkits}
-                  onAddToolkit={addToolkit}
-                  onRemoveToolkit={removeToolkit}
-                />
-              </div>
+            <div className="flex flex-col">
+              <ToolkitList
+                selectedToolkits={toolkits}
+                onAddToolkit={addToolkit}
+                onRemoveToolkit={removeToolkit}
+              />
               {workbench !== undefined && (
                 <div className="border-t p-2">
                   <Button

--- a/src/app/_components/chat/input/tools.tsx
+++ b/src/app/_components/chat/input/tools.tsx
@@ -31,6 +31,7 @@ import { clientToolkits } from "@/toolkits/toolkits/client";
 import { LanguageModelCapability } from "@/ai/types";
 
 import { cn } from "@/lib/utils";
+import { VStack } from "@/components/ui/stack";
 
 export const ToolsSelect = () => {
   const { toolkits, addToolkit, removeToolkit, workbench, selectedChatModel } =
@@ -127,22 +128,24 @@ export const ToolsSelect = () => {
       </PopoverTrigger>
 
       <PopoverContent
-        className="w-xs overflow-hidden p-0 md:w-lg"
+        className="h-96 w-xs overflow-hidden p-0 md:w-lg"
         align="start"
         sideOffset={8}
       >
-        <div className="bg-background sticky top-0 z-10 border-b p-2">
-          <h2 className="mb-1 text-sm font-bold">Toolkit Selector</h2>
-          <div className="text-muted-foreground text-sm">
-            Add or remove tools to enhance your chat experience
+        <div className="flex h-full max-h-full flex-col overflow-hidden">
+          <VStack className="items-start gap-0 p-2 pb-0">
+            <h2 className="mb-1 font-bold">Toolkit Selector</h2>
+            <p className="text-muted-foreground text-sm">
+              Add or remove tools to augment your chat experience
+            </p>
+          </VStack>
+          <div className="h-0 flex-1 overflow-hidden">
+            <ToolkitList
+              selectedToolkits={toolkits}
+              onAddToolkit={addToolkit}
+              onRemoveToolkit={removeToolkit}
+            />
           </div>
-        </div>
-        <div className="max-h-56 w-full max-w-full overflow-x-hidden overflow-y-auto py-2 pr-1 pl-2 md:max-h-80">
-          <ToolkitList
-            selectedToolkits={toolkits}
-            onAddToolkit={addToolkit}
-            onRemoveToolkit={removeToolkit}
-          />
           {workbench !== undefined && (
             <div className="border-t p-2">
               <Button

--- a/src/app/_components/chat/input/tools.tsx
+++ b/src/app/_components/chat/input/tools.tsx
@@ -191,8 +191,8 @@ export const ToolsSelect = () => {
         <Drawer open={isOpen} onOpenChange={setIsOpen}>
           <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
           <DrawerContent className="p-0">
-            <DrawerHeader className="items-start px-3 pb-2">
-              <DrawerTitle>Toolkit Selector</DrawerTitle>
+            <DrawerHeader className="items-start px-3 pb-3">
+              <DrawerTitle className="text-lg">Toolkit Selector</DrawerTitle>
               <DrawerDescription>
                 Add tools to give the model more capabilities
               </DrawerDescription>
@@ -203,7 +203,6 @@ export const ToolsSelect = () => {
       ) : (
         <Popover open={isOpen} onOpenChange={setIsOpen}>
           <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
-
           <PopoverContent
             className="w-xs overflow-hidden p-0 md:w-lg"
             align="start"

--- a/src/app/_components/chat/input/tools.tsx
+++ b/src/app/_components/chat/input/tools.tsx
@@ -1,17 +1,10 @@
 import { useEffect, useState } from "react";
 
-import { Loader2, Save, Wrench } from "lucide-react";
+import { Wrench } from "lucide-react";
 
-import { useRouter, useSearchParams } from "next/navigation";
-
-import { toast } from "sonner";
+import { useSearchParams } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import {
   TooltipContent,
   TooltipTrigger,
@@ -19,80 +12,25 @@ import {
   TooltipProvider,
 } from "@/components/ui/tooltip";
 
-import { ToolkitList } from "@/components/toolkit/toolkit-list";
 import { ToolkitIcons } from "@/components/toolkit/toolkit-icons";
+import { ToolkitSelect } from "@/components/toolkit/toolkit-select";
 
 import { useChatContext } from "@/app/_contexts/chat-context";
 
-import { api } from "@/trpc/react";
-
 import { clientToolkits } from "@/toolkits/toolkits/client";
+
+import { cn } from "@/lib/utils";
 
 import { LanguageModelCapability } from "@/ai/types";
 
-import { cn } from "@/lib/utils";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer";
-import { useIsMobile } from "@/hooks/use-mobile";
-import type { SelectedToolkit } from "@/components/toolkit/types";
-import type { Workbench } from "@prisma/client";
-import type { Toolkits } from "@/toolkits/toolkits/shared";
-
-// Shared content component for both dropdown and drawer
-const ToolkitSelectContent: React.FC<{
-  toolkits: SelectedToolkit[];
-  addToolkit: (toolkit: SelectedToolkit) => void;
-  removeToolkit: (id: Toolkits) => void;
-  workbench: (Workbench & { toolkitIds: string[] }) | undefined;
-  handleSave: () => void;
-  isPending: boolean;
-  isMobile?: boolean;
-}> = ({
-  toolkits,
-  addToolkit,
-  removeToolkit,
-  workbench,
-  handleSave,
-  isPending,
-}) => (
-  <div className={cn("w-full max-w-full")}>
-    <ToolkitList
-      selectedToolkits={toolkits}
-      onAddToolkit={addToolkit}
-      onRemoveToolkit={removeToolkit}
-    />
-    {workbench !== undefined && (
-      <div className="border-t p-2">
-        <Button
-          variant={"outline"}
-          className="w-full bg-transparent"
-          onClick={handleSave}
-          disabled={isPending}
-        >
-          {isPending ? <Loader2 className="animate-spin" /> : <Save />}
-          Save
-        </Button>
-      </div>
-    )}
-  </div>
-);
-
 export const ToolsSelect = () => {
-  const { toolkits, addToolkit, removeToolkit, workbench, selectedChatModel } =
+  const { toolkits, addToolkit, removeToolkit, selectedChatModel } =
     useChatContext();
   const searchParams = useSearchParams();
-  const isMobile = useIsMobile();
 
   const [isOpen, setIsOpen] = useState(
     Object.keys(clientToolkits).some((toolkit) => searchParams.get(toolkit)),
   );
-  const router = useRouter();
 
   useEffect(() => {
     if (
@@ -103,26 +41,6 @@ export const ToolsSelect = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const { mutate: updateWorkbench, isPending } =
-    api.workbenches.updateWorkbench.useMutation({
-      onSuccess: () => {
-        toast.success("Workbench updated successfully");
-        router.refresh();
-        setIsOpen(false);
-      },
-    });
-
-  const handleSave = () => {
-    if (workbench) {
-      updateWorkbench({
-        id: workbench.id,
-        name: workbench.name,
-        systemPrompt: workbench.systemPrompt,
-        toolkitIds: toolkits.map((toolkit) => toolkit.id),
-      });
-    }
-  };
 
   if (
     selectedChatModel &&
@@ -150,91 +68,38 @@ export const ToolsSelect = () => {
     );
   }
 
-  const triggerButton = (
-    <Button
-      variant={"outline"}
-      className={cn(
-        "w-fit justify-center bg-transparent md:w-auto md:px-2",
-        toolkits.length === 0 && "size-9 md:w-auto",
-      )}
-      disabled={
-        !selectedChatModel?.capabilities?.includes(
-          LanguageModelCapability.ToolCalling,
-        )
-      }
-    >
-      {toolkits.length > 0 ? (
-        <ToolkitIcons toolkits={toolkits.map((toolkit) => toolkit.id)} />
-      ) : (
-        <Wrench />
-      )}
-      <span className="hidden md:block">
-        {toolkits.length > 0
-          ? `${toolkits.length} Toolkit${toolkits.length > 1 ? "s" : ""}`
-          : "Add Toolkits"}
-      </span>
-    </Button>
-  );
-
-  const contentProps = {
-    toolkits,
-    addToolkit,
-    removeToolkit,
-    workbench,
-    handleSave,
-    isPending,
-  };
-
   return (
-    <TooltipProvider>
-      {isMobile ? (
-        <Drawer open={isOpen} onOpenChange={setIsOpen}>
-          <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
-          <DrawerContent className="p-0">
-            <DrawerHeader className="items-start px-3 pb-3">
-              <DrawerTitle className="text-lg">Toolkit Selector</DrawerTitle>
-              <DrawerDescription>
-                Add tools to give the model more capabilities
-              </DrawerDescription>
-            </DrawerHeader>
-            <ToolkitSelectContent {...contentProps} isMobile={true} />
-          </DrawerContent>
-        </Drawer>
-      ) : (
-        <Popover open={isOpen} onOpenChange={setIsOpen}>
-          <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
-          <PopoverContent
-            className="w-xs overflow-hidden p-0 md:w-lg"
-            align="start"
-            sideOffset={8}
-          >
-            <div className="flex flex-col">
-              <ToolkitList
-                selectedToolkits={toolkits}
-                onAddToolkit={addToolkit}
-                onRemoveToolkit={removeToolkit}
-              />
-              {workbench !== undefined && (
-                <div className="border-t p-2">
-                  <Button
-                    variant={"outline"}
-                    className="w-full bg-transparent"
-                    onClick={handleSave}
-                    disabled={isPending}
-                  >
-                    {isPending ? (
-                      <Loader2 className="animate-spin" />
-                    ) : (
-                      <Save />
-                    )}
-                    Save
-                  </Button>
-                </div>
-              )}
-            </div>
-          </PopoverContent>
-        </Popover>
-      )}
-    </TooltipProvider>
+    <ToolkitSelect
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      toolkits={toolkits}
+      addToolkit={addToolkit}
+      removeToolkit={removeToolkit}
+      triggerButton={
+        <Button
+          variant={"outline"}
+          className={cn(
+            "w-fit justify-center bg-transparent md:w-auto md:px-2",
+            toolkits.length === 0 && "size-9 md:w-auto",
+          )}
+          disabled={
+            !selectedChatModel?.capabilities?.includes(
+              LanguageModelCapability.ToolCalling,
+            )
+          }
+        >
+          {toolkits.length > 0 ? (
+            <ToolkitIcons toolkits={toolkits.map((toolkit) => toolkit.id)} />
+          ) : (
+            <Wrench />
+          )}
+          <span className="hidden md:block">
+            {toolkits.length > 0
+              ? `${toolkits.length} Toolkit${toolkits.length > 1 ? "s" : ""}`
+              : "Add Toolkits"}
+          </span>
+        </Button>
+      }
+    />
   );
 };

--- a/src/app/_components/chat/input/tools.tsx
+++ b/src/app/_components/chat/input/tools.tsx
@@ -1,23 +1,36 @@
+import { useEffect, useState } from "react";
+
+import { Loader2, Save, Wrench } from "lucide-react";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   TooltipContent,
   TooltipTrigger,
   Tooltip,
   TooltipProvider,
 } from "@/components/ui/tooltip";
-import { Loader2, Save, Wrench } from "lucide-react";
-import { useChatContext } from "@/app/_contexts/chat-context";
-import { useEffect, useState } from "react";
+
 import { ToolkitList } from "@/components/toolkit/toolkit-list";
-import { useRouter, useSearchParams } from "next/navigation";
-import { api } from "@/trpc/react";
-import { toast } from "sonner";
 import { ToolkitIcons } from "@/components/toolkit/toolkit-icons";
+
+import { useChatContext } from "@/app/_contexts/chat-context";
+
+import { api } from "@/trpc/react";
+
 import { clientToolkits } from "@/toolkits/toolkits/client";
+
 import { LanguageModelCapability } from "@/ai/types";
+
 import { cn } from "@/lib/utils";
-import { DropdownMenu, DropdownMenuTrigger } from "@radix-ui/react-dropdown-menu";
-import { DropdownMenuContent } from "@/components/ui/dropdown-menu";
 
 export const ToolsSelect = () => {
   const { toolkits, addToolkit, removeToolkit, workbench, selectedChatModel } =
@@ -86,67 +99,65 @@ export const ToolsSelect = () => {
   }
 
   return (
-    <TooltipProvider>
-      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant={"outline"}
-            className={cn(
-              "w-fit justify-center bg-transparent md:w-auto md:px-2",
-              toolkits.length === 0 && "size-9 md:w-auto",
-            )}
-            disabled={
-              !selectedChatModel?.capabilities?.includes(
-                LanguageModelCapability.ToolCalling,
-              )
-            }
-          >
-            {toolkits.length > 0 ? (
-              <ToolkitIcons toolkits={toolkits.map((toolkit) => toolkit.id)} />
-            ) : (
-              <Wrench />
-            )}
-            <span className="hidden md:block">
-              {toolkits.length > 0
-                ? `${toolkits.length} Toolkit${toolkits.length > 1 ? "s" : ""}`
-                : "Add Toolkits"}
-            </span>
-          </Button>
-        </DropdownMenuTrigger>
-
-       <DropdownMenuContent
-          className="w-xs overflow-hidden p-0 md:w-lg"
-          align="start"
-          sideOffset={8}
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant={"outline"}
+          className={cn(
+            "w-fit justify-center bg-transparent md:w-auto md:px-2",
+            toolkits.length === 0 && "size-9 md:w-auto",
+          )}
+          disabled={
+            !selectedChatModel?.capabilities?.includes(
+              LanguageModelCapability.ToolCalling,
+            )
+          }
         >
-          <div className="bg-background sticky top-0 z-10 border-b p-2">
-            <h2 className="mb-1 text-sm font-bold">Toolkit Selector</h2>
-            <div className="text-muted-foreground text-sm">
-              Add or remove tools to enhance your chat experience
+          {toolkits.length > 0 ? (
+            <ToolkitIcons toolkits={toolkits.map((toolkit) => toolkit.id)} />
+          ) : (
+            <Wrench />
+          )}
+          <span className="hidden md:block">
+            {toolkits.length > 0
+              ? `${toolkits.length} Toolkit${toolkits.length > 1 ? "s" : ""}`
+              : "Add Toolkits"}
+          </span>
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        className="w-xs overflow-hidden p-0 md:w-lg"
+        align="start"
+        sideOffset={8}
+      >
+        <div className="bg-background sticky top-0 z-10 border-b p-2">
+          <h2 className="mb-1 text-sm font-bold">Toolkit Selector</h2>
+          <div className="text-muted-foreground text-sm">
+            Add or remove tools to enhance your chat experience
+          </div>
+        </div>
+        <div className="max-h-56 w-full max-w-full overflow-x-hidden overflow-y-auto py-2 pr-1 pl-2 md:max-h-80">
+          <ToolkitList
+            selectedToolkits={toolkits}
+            onAddToolkit={addToolkit}
+            onRemoveToolkit={removeToolkit}
+          />
+          {workbench !== undefined && (
+            <div className="border-t p-2">
+              <Button
+                variant={"outline"}
+                className="w-full bg-transparent"
+                onClick={handleSave}
+                disabled={isPending}
+              >
+                {isPending ? <Loader2 className="animate-spin" /> : <Save />}
+                Save
+              </Button>
             </div>
-          </div>
-          <div className="max-h-56 w-full pl-2 pr-1 py-2 max-w-full overflow-x-hidden overflow-y-auto md:max-h-80">
-            <ToolkitList
-              selectedToolkits={toolkits}
-              onAddToolkit={addToolkit}
-              onRemoveToolkit={removeToolkit}
-            />
-            {workbench !== undefined && (
-              <div className="p-2 border-t">
-                <Button
-                  variant={"outline"}
-                  className="bg-transparent w-full"
-                  onClick={handleSave}
-                  disabled={isPending}
-                >
-                  {isPending ? <Loader2 className="animate-spin" /> : <Save />}
-                  Save
-                </Button>
-              </div>
-            )}
-          </div>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </TooltipProvider>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 };

--- a/src/app/_components/chat/input/tools.tsx
+++ b/src/app/_components/chat/input/tools.tsx
@@ -191,7 +191,7 @@ export const ToolsSelect = () => {
         <Drawer open={isOpen} onOpenChange={setIsOpen}>
           <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
           <DrawerContent className="p-0">
-            <DrawerHeader className="items-start">
+            <DrawerHeader className="items-start px-3 pb-2">
               <DrawerTitle>Toolkit Selector</DrawerTitle>
               <DrawerDescription>
                 Add tools to give the model more capabilities

--- a/src/app/_components/chat/input/tools.tsx
+++ b/src/app/_components/chat/input/tools.tsx
@@ -233,7 +233,7 @@ export const ToolsSelect = () => {
           <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
 
           <PopoverContent
-            className="h-96 w-xs overflow-hidden p-0 md:w-lg"
+            className="w-xs overflow-hidden p-0 md:w-lg"
             align="start"
             sideOffset={8}
           >

--- a/src/app/_components/chat/input/tools.tsx
+++ b/src/app/_components/chat/input/tools.tsx
@@ -24,7 +24,7 @@ import { cn } from "@/lib/utils";
 import { LanguageModelCapability } from "@/ai/types";
 
 export const ToolsSelect = () => {
-  const { toolkits, addToolkit, removeToolkit, selectedChatModel } =
+  const { toolkits, addToolkit, removeToolkit, selectedChatModel, workbench } =
     useChatContext();
   const searchParams = useSearchParams();
 
@@ -75,31 +75,31 @@ export const ToolsSelect = () => {
       toolkits={toolkits}
       addToolkit={addToolkit}
       removeToolkit={removeToolkit}
-      triggerButton={
-        <Button
-          variant={"outline"}
-          className={cn(
-            "w-fit justify-center bg-transparent md:w-auto md:px-2",
-            toolkits.length === 0 && "size-9 md:w-auto",
-          )}
-          disabled={
-            !selectedChatModel?.capabilities?.includes(
-              LanguageModelCapability.ToolCalling,
-            )
-          }
-        >
-          {toolkits.length > 0 ? (
-            <ToolkitIcons toolkits={toolkits.map((toolkit) => toolkit.id)} />
-          ) : (
-            <Wrench />
-          )}
-          <span className="hidden md:block">
-            {toolkits.length > 0
-              ? `${toolkits.length} Toolkit${toolkits.length > 1 ? "s" : ""}`
-              : "Add Toolkits"}
-          </span>
-        </Button>
-      }
-    />
+      workbench={workbench}
+    >
+      <Button
+        variant={"outline"}
+        className={cn(
+          "w-fit justify-center bg-transparent md:w-auto md:px-2",
+          toolkits.length === 0 && "size-9 md:w-auto",
+        )}
+        disabled={
+          !selectedChatModel?.capabilities?.includes(
+            LanguageModelCapability.ToolCalling,
+          )
+        }
+      >
+        {toolkits.length > 0 ? (
+          <ToolkitIcons toolkits={toolkits.map((toolkit) => toolkit.id)} />
+        ) : (
+          <Wrench />
+        )}
+        <span className="hidden md:block">
+          {toolkits.length > 0
+            ? `${toolkits.length} Toolkit${toolkits.length > 1 ? "s" : ""}`
+            : "Add Toolkits"}
+        </span>
+      </Button>
+    </ToolkitSelect>
   );
 };

--- a/src/app/_components/welcome-dialog.tsx
+++ b/src/app/_components/welcome-dialog.tsx
@@ -59,8 +59,8 @@ export function WelcomeDialog() {
 
   return (
     <AlertDialog defaultOpen>
-      <AlertDialogContent className="flex max-h-[90vh] w-full flex-col overflow-hidden p-3 sm:max-w-2xl md:p-6">
-        <div className="flex flex-col justify-between gap-2 md:flex-row">
+      <AlertDialogContent className="flex h-[90vh] w-full flex-col gap-2 overflow-hidden p-1 sm:max-w-2xl md:h-[60vh] md:p-3">
+        <div className="flex flex-col justify-between gap-2 px-2 md:flex-row">
           <AlertDialogHeader className="gap-0 text-left">
             <AlertDialogTitle className="text-primary text-lg font-bold md:text-2xl">
               Start by Selecting Your Toolkits

--- a/src/app/_components/welcome-dialog.tsx
+++ b/src/app/_components/welcome-dialog.tsx
@@ -16,6 +16,7 @@ import { getClientToolkit } from "@/toolkits/toolkits/client";
 import type { ClientToolkit } from "@/toolkits/types";
 import { useChatContext } from "@/app/_contexts/chat-context";
 import { usePathname, useRouter } from "next/navigation";
+import { VStack } from "@/components/ui/stack";
 
 export function WelcomeDialog() {
   const { toolkits, addToolkit, removeToolkit } = useChatContext();
@@ -59,8 +60,8 @@ export function WelcomeDialog() {
 
   return (
     <AlertDialog defaultOpen>
-      <AlertDialogContent className="flex h-[90vh] w-full flex-col gap-2 overflow-hidden p-1 sm:max-w-2xl md:h-[60vh] md:p-3">
-        <div className="flex flex-col justify-between gap-2 px-2 md:flex-row">
+      <AlertDialogContent className="flex w-full flex-col gap-2 overflow-hidden p-0 sm:max-w-2xl md:gap-0">
+        <div className="flex flex-col justify-between gap-2 p-2 md:flex-row md:p-4">
           <AlertDialogHeader className="gap-0 text-left">
             <AlertDialogTitle className="text-primary text-lg font-bold md:text-2xl">
               Start by Selecting Your Toolkits
@@ -79,27 +80,26 @@ export function WelcomeDialog() {
           </AlertDialogAction>
         </div>
 
-        <div className="h-0 flex-1 overflow-y-auto">
-          <ToolkitList
-            selectedToolkits={toolkits}
-            onAddToolkit={addToolkit}
-            onRemoveToolkit={removeToolkit}
-          />
-        </div>
-
-        <p className="text-muted-foreground hidden text-center text-sm md:block">
-          Toolkits are collections of specialized tools that extend the
-          AI&apos;s capabilities. You can add web search, code execution, image
-          generation, and more to customize your experience.
-        </p>
-        <AlertDialogAction
-          className="user-message shrink-0 md:hidden"
-          onClick={() => {
-            router.replace(pathname);
-          }}
-        >
-          Continue to Chat <ArrowRight className="ml-2 size-4" />
-        </AlertDialogAction>
+        <ToolkitList
+          selectedToolkits={toolkits}
+          onAddToolkit={addToolkit}
+          onRemoveToolkit={removeToolkit}
+        />
+        <VStack className="p-2 md:p-4">
+          <p className="text-muted-foreground hidden text-center text-sm md:block">
+            Toolkits are collections of specialized tools that extend the
+            AI&apos;s capabilities. You can add web search, code execution,
+            image generation, and more to customize your experience.
+          </p>
+          <AlertDialogAction
+            className="user-message w-full shrink-0 md:hidden"
+            onClick={() => {
+              router.replace(pathname);
+            }}
+          >
+            Continue to Chat <ArrowRight className="ml-2 size-4" />
+          </AlertDialogAction>
+        </VStack>
       </AlertDialogContent>
     </AlertDialog>
   );

--- a/src/app/workbench/[id]/edit/_components/edit-workbench-form.tsx
+++ b/src/app/workbench/[id]/edit/_components/edit-workbench-form.tsx
@@ -1,31 +1,32 @@
 "use client";
 
 import { useState } from "react";
+
+import Link from "next/link";
+
+import { Anvil, Plus } from "lucide-react";
+
 import { useRouter } from "next/navigation";
-import { api } from "@/trpc/react";
+
+import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { VStack, HStack } from "@/components/ui/stack";
-import { ToolkitList } from "@/components/toolkit/toolkit-list";
-import type { SelectedToolkit } from "@/components/toolkit/types";
-import type { Toolkits } from "@/toolkits/toolkits/shared";
-import Link from "next/link";
-import { toast } from "sonner";
-import {
-  Dialog,
-  DialogDescription,
-  DialogTitle,
-  DialogHeader,
-  DialogContent,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Anvil, Plus } from "lucide-react";
+
 import { ToolkitIcons } from "@/components/toolkit/toolkit-icons";
+import { ToolkitSelect } from "@/components/toolkit/toolkit-select";
+
+import { api } from "@/trpc/react";
+
 import { clientToolkits } from "@/toolkits/toolkits/client";
 import { getClientToolkit } from "@/toolkits/toolkits/client";
+
 import type { Workbench } from "@prisma/client";
+import type { SelectedToolkit } from "@/components/toolkit/types";
+import type { Toolkits } from "@/toolkits/toolkits/shared";
 
 interface EditWorkbenchFormProps {
   workbench: Workbench;
@@ -35,6 +36,7 @@ export function EditWorkbenchForm({ workbench }: EditWorkbenchFormProps) {
   const router = useRouter();
   const [name, setName] = useState(workbench.name);
   const [systemPrompt, setSystemPrompt] = useState(workbench.systemPrompt);
+  const [isToolkitSelectOpen, setIsToolkitSelectOpen] = useState(false);
   const [selectedToolkits, setSelectedToolkits] = useState<SelectedToolkit[]>(
     workbench.toolkitIds.map((id) => {
       const typedId = id as Toolkits;
@@ -145,58 +147,41 @@ export function EditWorkbenchForm({ workbench }: EditWorkbenchFormProps) {
             {/* Toolkit Selection */}
             <VStack className="w-full items-start gap-2">
               <Label className="text-base font-semibold">Select Toolkits</Label>
-              <Dialog>
-                <DialogTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start px-2"
-                  >
-                    {selectedToolkits.length > 0 ? (
-                      <HStack className="w-full">
-                        <ToolkitIcons
-                          toolkits={selectedToolkits.map(
-                            (toolkit) => toolkit.id,
-                          )}
-                        />
+              <ToolkitSelect
+                isOpen={isToolkitSelectOpen}
+                onOpenChange={setIsToolkitSelectOpen}
+                toolkits={selectedToolkits}
+                addToolkit={handleAddToolkit}
+                removeToolkit={handleRemoveToolkit}
+              >
+                <Button variant="outline" className="w-full justify-start px-2">
+                  {selectedToolkits.length > 0 ? (
+                    <HStack className="w-full">
+                      <ToolkitIcons
+                        toolkits={selectedToolkits.map((toolkit) => toolkit.id)}
+                      />
+                      <p className="text-muted-foreground text-xs">
+                        {selectedToolkits.length} Toolkit
+                        {selectedToolkits.length !== 1 ? "s" : ""} selected
+                      </p>
+                    </HStack>
+                  ) : (
+                    <HStack className="w-full justify-between">
+                      <HStack className="flex items-center gap-2">
+                        <Plus className="text-muted-foreground size-4" />
                         <p className="text-muted-foreground text-xs">
-                          {selectedToolkits.length} Toolkit
-                          {selectedToolkits.length !== 1 ? "s" : ""} selected
+                          Select toolkits...
                         </p>
                       </HStack>
-                    ) : (
-                      <HStack className="w-full justify-between">
-                        <HStack className="flex items-center gap-2">
-                          <Plus className="text-muted-foreground size-4" />
-                          <p className="text-muted-foreground text-xs">
-                            Select toolkits...
-                          </p>
-                        </HStack>
-                        <ToolkitIcons
-                          toolkits={Object.keys(clientToolkits) as Toolkits[]}
-                          iconContainerClassName="bg-background"
-                          iconClassName="text-muted-foreground"
-                        />
-                      </HStack>
-                    )}
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="flex h-[90vh] max-w-lg flex-col gap-2 overflow-hidden p-1 md:h-[60vh] md:p-3">
-                  <DialogHeader className="flex-0 gap-1 px-2 pt-2">
-                    <DialogTitle>Select Toolkits</DialogTitle>
-                    <DialogDescription>
-                      Choose the toolkits that will be available in this
-                      workbench.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className="flex-1 overflow-y-auto">
-                    <ToolkitList
-                      selectedToolkits={selectedToolkits}
-                      onAddToolkit={handleAddToolkit}
-                      onRemoveToolkit={handleRemoveToolkit}
-                    />
-                  </div>
-                </DialogContent>
-              </Dialog>
+                      <ToolkitIcons
+                        toolkits={Object.keys(clientToolkits) as Toolkits[]}
+                        iconContainerClassName="bg-background"
+                        iconClassName="text-muted-foreground"
+                      />
+                    </HStack>
+                  )}
+                </Button>
+              </ToolkitSelect>
               <p className="text-muted-foreground text-xs">
                 Select the toolkits that will be available in this workbench.
               </p>

--- a/src/app/workbench/[id]/edit/_components/edit-workbench-form.tsx
+++ b/src/app/workbench/[id]/edit/_components/edit-workbench-form.tsx
@@ -180,8 +180,8 @@ export function EditWorkbenchForm({ workbench }: EditWorkbenchFormProps) {
                     )}
                   </Button>
                 </DialogTrigger>
-                <DialogContent className="max-h-[80vh] max-w-lg gap-2 overflow-hidden">
-                  <DialogHeader className="gap-1">
+                <DialogContent className="flex h-[90vh] max-w-lg flex-col gap-2 overflow-hidden p-1 md:h-[60vh] md:p-3">
+                  <DialogHeader className="flex-0 gap-1 px-2 pt-2">
                     <DialogTitle>Select Toolkits</DialogTitle>
                     <DialogDescription>
                       Choose the toolkits that will be available in this

--- a/src/app/workbench/new/_components/new-workbench-form.tsx
+++ b/src/app/workbench/new/_components/new-workbench-form.tsx
@@ -167,8 +167,8 @@ export function NewWorkbenchForm() {
                     )}
                   </Button>
                 </DialogTrigger>
-                <DialogContent className="h-[90vh] max-w-lg gap-2 overflow-hidden p-1 md:h-[60vh] md:p-3">
-                  <DialogHeader className="gap-1 px-2 pt-2">
+                <DialogContent className="flex h-[90vh] max-w-lg flex-col gap-2 overflow-hidden p-1 md:h-[60vh] md:p-3">
+                  <DialogHeader className="flex-0 gap-1 px-2 pt-2">
                     <DialogTitle>Select Toolkits</DialogTitle>
                     <DialogDescription>
                       Choose the toolkits that will be available in this

--- a/src/app/workbench/new/_components/new-workbench-form.tsx
+++ b/src/app/workbench/new/_components/new-workbench-form.tsx
@@ -1,33 +1,34 @@
 "use client";
 
 import { useState } from "react";
+
+import { Anvil, Plus } from "lucide-react";
+
 import { useRouter } from "next/navigation";
-import { api } from "@/trpc/react";
+
+import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { VStack, HStack } from "@/components/ui/stack";
-import { ToolkitList } from "@/components/toolkit/toolkit-list";
+
+import { ToolkitIcons } from "@/components/toolkit/toolkit-icons";
+import { ToolkitSelect } from "@/components/toolkit/toolkit-select";
+
+import { api } from "@/trpc/react";
+
+import { clientToolkits } from "@/toolkits/toolkits/client";
+
 import type { SelectedToolkit } from "@/components/toolkit/types";
 import type { Toolkits } from "@/toolkits/toolkits/shared";
-import { toast } from "sonner";
-import {
-  Dialog,
-  DialogDescription,
-  DialogTitle,
-  DialogHeader,
-  DialogContent,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Anvil, Plus } from "lucide-react";
-import { ToolkitIcons } from "@/components/toolkit/toolkit-icons";
-import { clientToolkits } from "@/toolkits/toolkits/client";
 
 export function NewWorkbenchForm() {
   const router = useRouter();
   const [name, setName] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
+  const [isToolkitSelectOpen, setIsToolkitSelectOpen] = useState(false);
   const [selectedToolkits, setSelectedToolkits] = useState<SelectedToolkit[]>(
     [],
   );
@@ -132,58 +133,41 @@ export function NewWorkbenchForm() {
             {/* Toolkit Selection */}
             <VStack className="w-full items-start gap-2">
               <Label className="text-base font-semibold">Select Toolkits</Label>
-              <Dialog>
-                <DialogTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start px-2"
-                  >
-                    {selectedToolkits.length > 0 ? (
-                      <HStack className="w-full">
-                        <ToolkitIcons
-                          toolkits={selectedToolkits.map(
-                            (toolkit) => toolkit.id,
-                          )}
-                        />
+              <ToolkitSelect
+                isOpen={isToolkitSelectOpen}
+                onOpenChange={setIsToolkitSelectOpen}
+                toolkits={selectedToolkits}
+                addToolkit={handleAddToolkit}
+                removeToolkit={handleRemoveToolkit}
+              >
+                <Button variant="outline" className="w-full justify-start px-2">
+                  {selectedToolkits.length > 0 ? (
+                    <HStack className="w-full">
+                      <ToolkitIcons
+                        toolkits={selectedToolkits.map((toolkit) => toolkit.id)}
+                      />
+                      <p className="text-muted-foreground text-xs">
+                        {selectedToolkits.length} Toolkit
+                        {selectedToolkits.length !== 1 ? "s" : ""} selected
+                      </p>
+                    </HStack>
+                  ) : (
+                    <HStack className="w-full justify-between">
+                      <HStack className="flex items-center gap-2">
+                        <Plus className="text-muted-foreground size-4" />
                         <p className="text-muted-foreground text-xs">
-                          {selectedToolkits.length} Toolkit
-                          {selectedToolkits.length !== 1 ? "s" : ""} selected
+                          Select toolkits...
                         </p>
                       </HStack>
-                    ) : (
-                      <HStack className="w-full justify-between">
-                        <HStack className="flex items-center gap-2">
-                          <Plus className="text-muted-foreground size-4" />
-                          <p className="text-muted-foreground text-xs">
-                            Select toolkits...
-                          </p>
-                        </HStack>
-                        <ToolkitIcons
-                          toolkits={Object.keys(clientToolkits) as Toolkits[]}
-                          iconContainerClassName="bg-background"
-                          iconClassName="text-muted-foreground"
-                        />
-                      </HStack>
-                    )}
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="flex h-[90vh] max-w-lg flex-col gap-2 overflow-hidden p-1 md:h-[60vh] md:p-3">
-                  <DialogHeader className="flex-0 gap-1 px-2 pt-2">
-                    <DialogTitle>Select Toolkits</DialogTitle>
-                    <DialogDescription>
-                      Choose the toolkits that will be available in this
-                      workbench.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className="flex-1 overflow-y-auto">
-                    <ToolkitList
-                      selectedToolkits={selectedToolkits}
-                      onAddToolkit={handleAddToolkit}
-                      onRemoveToolkit={handleRemoveToolkit}
-                    />
-                  </div>
-                </DialogContent>
-              </Dialog>
+                      <ToolkitIcons
+                        toolkits={Object.keys(clientToolkits) as Toolkits[]}
+                        iconContainerClassName="bg-background"
+                        iconClassName="text-muted-foreground"
+                      />
+                    </HStack>
+                  )}
+                </Button>
+              </ToolkitSelect>
               <p className="text-muted-foreground text-xs">
                 Select the toolkits that will be available in this workbench.
               </p>

--- a/src/app/workbench/new/_components/new-workbench-form.tsx
+++ b/src/app/workbench/new/_components/new-workbench-form.tsx
@@ -167,8 +167,8 @@ export function NewWorkbenchForm() {
                     )}
                   </Button>
                 </DialogTrigger>
-                <DialogContent className="max-h-[80vh] max-w-lg gap-2 overflow-hidden">
-                  <DialogHeader className="gap-1">
+                <DialogContent className="h-[90vh] max-w-lg gap-2 overflow-hidden p-1 md:h-[60vh] md:p-3">
+                  <DialogHeader className="gap-1 px-2 pt-2">
                     <DialogTitle>Select Toolkits</DialogTitle>
                     <DialogDescription>
                       Choose the toolkits that will be available in this

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useMemo, useState } from "react";
 
-import { Plus, Info, Search } from "lucide-react";
+import { Info } from "lucide-react";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -18,7 +17,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { HStack } from "@/components/ui/stack";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Command,
   CommandEmpty,
@@ -32,10 +30,11 @@ import { ClientToolkitConfigure } from "@/components/toolkit/toolkit-configure";
 
 import { clientToolkits } from "@/toolkits/toolkits/client";
 
+import { cn } from "@/lib/utils";
+
 import type { ClientToolkit } from "@/toolkits/types";
 import type { Toolkits } from "@/toolkits/toolkits/shared";
 import type { SelectedToolkit } from "./types";
-import { cn } from "@/lib/utils";
 
 interface ToolkitListProps {
   selectedToolkits: SelectedToolkit[];
@@ -44,6 +43,7 @@ interface ToolkitListProps {
 }
 
 const toolkitItemHeight = 48;
+const numToolkitsToShow = 5;
 
 export const ToolkitList: React.FC<ToolkitListProps> = ({
   selectedToolkits,
@@ -126,7 +126,11 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
               value={searchQuery}
               onValueChange={setSearchQuery}
             />
-            <CommandList style={{ height: `${toolkitItemHeight * 3.5}px` }}>
+            <CommandList
+              style={{
+                height: `${toolkitItemHeight * (numToolkitsToShow + 0.5)}px`,
+              }}
+            >
               <CommandEmpty>No toolkits match your search</CommandEmpty>
               <CommandGroup className="p-0">
                 {filteredToolkits.map(([id, toolkit]) => {

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -8,7 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { HStack, VStack } from "@/components/ui/stack";
+import { VStack } from "@/components/ui/stack";
 import {
   Command,
   CommandEmpty,

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 
+import { Loader2 } from "lucide-react";
+
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import {
@@ -27,7 +29,6 @@ import { cn } from "@/lib/utils";
 import type { ClientToolkit } from "@/toolkits/types";
 import type { Toolkits } from "@/toolkits/toolkits/shared";
 import type { SelectedToolkit } from "./types";
-import { Loader2 } from "lucide-react";
 
 interface ToolkitListProps {
   selectedToolkits: SelectedToolkit[];

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -49,7 +49,6 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
   const router = useRouter();
 
   const [searchQuery, setSearchQuery] = useState("");
-  const [configureDialogOpen, setConfigureDialogOpen] = useState(false);
   const [selectedToolkitForConfig, setSelectedToolkitForConfig] = useState<{
     id: Toolkits;
     toolkit: ClientToolkit;
@@ -181,7 +180,10 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
           </CommandGroup>
         </CommandList>
       </Command>
-      <Dialog open={configureDialogOpen} onOpenChange={setConfigureDialogOpen}>
+      <Dialog
+        open={selectedToolkitForConfig !== null}
+        onOpenChange={() => setSelectedToolkitForConfig(null)}
+      >
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
             <DialogTitle>

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -87,18 +87,26 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
             />
           </div>
           <VStack className="h-0 w-full flex-1 items-start overflow-y-auto">
-            {filteredToolkits.map(([id, toolkit]) => {
-              return (
-                <ToolkitItem
-                  key={id}
-                  id={id as Toolkits}
-                  toolkit={toolkit as ClientToolkit}
-                  selectedToolkits={selectedToolkits}
-                  onAddToolkit={onAddToolkit}
-                  onRemoveToolkit={onRemoveToolkit}
-                />
-              );
-            })}
+            {filteredToolkits.length === 0 ? (
+              <div className="flex-1 items-center justify-center">
+                <p className="text-muted-foreground text-sm">
+                  No toolkits match your search
+                </p>
+              </div>
+            ) : (
+              filteredToolkits.map(([id, toolkit]) => {
+                return (
+                  <ToolkitItem
+                    key={id}
+                    id={id as Toolkits}
+                    toolkit={toolkit as ClientToolkit}
+                    selectedToolkits={selectedToolkits}
+                    onAddToolkit={onAddToolkit}
+                    onRemoveToolkit={onRemoveToolkit}
+                  />
+                );
+              })
+            )}
           </VStack>
         </div>
       </TooltipProvider>

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -27,6 +27,7 @@ import { cn } from "@/lib/utils";
 import type { ClientToolkit } from "@/toolkits/types";
 import type { Toolkits } from "@/toolkits/toolkits/shared";
 import type { SelectedToolkit } from "./types";
+import { Loader2 } from "lucide-react";
 
 interface ToolkitListProps {
   selectedToolkits: SelectedToolkit[];
@@ -126,16 +127,25 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
                 (t) => t.id === (id as Toolkits),
               );
 
-              const item = (
+              const Item = ({
+                isLoading,
+                onSelect,
+              }: {
+                isLoading: boolean;
+                onSelect?: () => void;
+              }) => (
                 <CommandItem
                   key={id}
-                  onSelect={() =>
-                    handleToolkitAction(
-                      id as Toolkits,
-                      toolkit as ClientToolkit,
-                    )
+                  onSelect={
+                    onSelect ??
+                    (() =>
+                      handleToolkitAction(
+                        id as Toolkits,
+                        toolkit as ClientToolkit,
+                      ))
                   }
                   className="flex items-center gap-2 rounded-none px-3"
+                  disabled={isLoading}
                 >
                   <div
                     className={cn(
@@ -143,9 +153,13 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
                       isSelected && "border-primary text-primary",
                     )}
                   >
-                    <toolkit.icon
-                      className={cn("size-4", isSelected && "text-primary")}
-                    />
+                    {isLoading ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <toolkit.icon
+                        className={cn("size-4", isSelected && "text-primary")}
+                      />
+                    )}
                   </div>
 
                   <VStack className="flex flex-1 flex-col items-start gap-0">
@@ -157,15 +171,11 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
                 </CommandItem>
               );
 
-              if (toolkit.addToolkitWrapper) {
-                return (
-                  <toolkit.addToolkitWrapper key={id}>
-                    {item}
-                  </toolkit.addToolkitWrapper>
-                );
+              if (toolkit.Wrapper) {
+                return <toolkit.Wrapper key={id} Item={Item} />;
               }
 
-              return item;
+              return <Item key={id} isLoading={false} />;
             })}
           </CommandGroup>
         </CommandList>

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
 
-import { Info } from "lucide-react";
-
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import {
@@ -10,13 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { HStack } from "@/components/ui/stack";
+import { HStack, VStack } from "@/components/ui/stack";
 import {
   Command,
   CommandEmpty,
@@ -98,7 +90,6 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
       onRemoveToolkit(id);
     } else if (needsConfiguration) {
       setSelectedToolkitForConfig({ id, toolkit });
-      setConfigureDialogOpen(true);
     } else {
       onAddToolkit({ id, toolkit, parameters: {} });
     }
@@ -111,96 +102,74 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
         toolkit: selectedToolkitForConfig.toolkit,
         parameters,
       });
-      setConfigureDialogOpen(false);
       setSelectedToolkitForConfig(null);
     }
   };
 
   return (
-    <div className="overflow-hidden">
-      <TooltipProvider>
-        <div className="flex h-full max-h-full flex-col gap-2 overflow-hidden">
-          <Command className="bg-transparent">
-            <CommandInput
-              placeholder="Search toolkits..."
-              value={searchQuery}
-              onValueChange={setSearchQuery}
-            />
-            <CommandList
-              style={{
-                height: `${toolkitItemHeight * (numToolkitsToShow + 0.5)}px`,
-              }}
-            >
-              <CommandEmpty>No toolkits match your search</CommandEmpty>
-              <CommandGroup className="p-0">
-                {filteredToolkits.map(([id, toolkit]) => {
-                  const isSelected = selectedToolkits.some(
-                    (t) => t.id === (id as Toolkits),
-                  );
+    <>
+      <Command className="bg-transparent">
+        <CommandInput
+          placeholder="Search toolkits..."
+          value={searchQuery}
+          onValueChange={setSearchQuery}
+        />
+        <CommandList
+          style={{
+            height: `${toolkitItemHeight * (numToolkitsToShow + 0.5)}px`,
+          }}
+        >
+          <CommandEmpty>No toolkits match your search</CommandEmpty>
+          <CommandGroup className="p-0">
+            {filteredToolkits.map(([id, toolkit]) => {
+              const isSelected = selectedToolkits.some(
+                (t) => t.id === (id as Toolkits),
+              );
 
-                  return (
-                    <CommandItem
-                      key={id}
-                      onSelect={() =>
-                        handleToolkitAction(
-                          id as Toolkits,
-                          toolkit as ClientToolkit,
-                        )
-                      }
-                      className="flex items-center justify-between gap-4 rounded-none px-3"
-                    >
-                      <div className="flex flex-1 flex-col">
-                        <HStack>
-                          <toolkit.icon
-                            className={cn(
-                              "size-4",
-                              isSelected && "text-primary",
-                            )}
-                          />
-                          <h3 className="text-sm font-medium">
-                            {toolkit.name}
-                          </h3>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Info className="text-muted-foreground size-3 cursor-pointer" />
-                            </TooltipTrigger>
-                            <TooltipContent side="right" className="max-w-64">
-                              <div className="space-y-2">
-                                <p className="text-sm font-medium">
-                                  Available Tools
-                                </p>
-                                <ul className="space-y-1">
-                                  {Object.entries(toolkit.tools).map(
-                                    ([name, tool]) => (
-                                      <li
-                                        key={name}
-                                        className="flex items-start gap-2"
-                                      >
-                                        <div className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-current" />
-                                        <p className="text-xs">
-                                          {tool.description}
-                                        </p>
-                                      </li>
-                                    ),
-                                  )}
-                                </ul>
-                              </div>
-                            </TooltipContent>
-                          </Tooltip>
-                        </HStack>
-                        <p className="text-muted-foreground text-xs">
-                          {toolkit.description}
-                        </p>
-                      </div>
-                    </CommandItem>
-                  );
-                })}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </div>
-      </TooltipProvider>
+              const item = (
+                <CommandItem
+                  key={id}
+                  onSelect={() =>
+                    handleToolkitAction(
+                      id as Toolkits,
+                      toolkit as ClientToolkit,
+                    )
+                  }
+                  className="flex items-center gap-2 rounded-none px-3"
+                >
+                  <div
+                    className={cn(
+                      "rounded-full border p-1",
+                      isSelected && "border-primary text-primary",
+                    )}
+                  >
+                    <toolkit.icon
+                      className={cn("size-4", isSelected && "text-primary")}
+                    />
+                  </div>
 
+                  <VStack className="flex flex-1 flex-col items-start gap-0">
+                    <h3 className="text-sm font-medium">{toolkit.name}</h3>
+                    <p className="text-muted-foreground text-xs">
+                      {toolkit.description}
+                    </p>
+                  </VStack>
+                </CommandItem>
+              );
+
+              if (toolkit.addToolkitWrapper) {
+                return (
+                  <toolkit.addToolkitWrapper key={id}>
+                    {item}
+                  </toolkit.addToolkitWrapper>
+                );
+              }
+
+              return item;
+            })}
+          </CommandGroup>
+        </CommandList>
+      </Command>
       <Dialog open={configureDialogOpen} onOpenChange={setConfigureDialogOpen}>
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
@@ -218,6 +187,6 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
           )}
         </DialogContent>
       </Dialog>
-    </div>
+    </>
   );
 };

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -74,31 +74,35 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
   }, [searchParams, onAddToolkit, selectedToolkits, router, pathname]);
 
   return (
-    <TooltipProvider>
-      <div className="relative mb-2">
-        <Search className="text-muted-foreground absolute top-2.5 left-2 size-4" />
-        <Input
-          placeholder="Search toolkits..."
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="pl-8"
-        />
-      </div>
-      <VStack className="w-full items-start">
-        {filteredToolkits.map(([id, toolkit]) => {
-          return (
-            <ToolkitItem
-              key={id}
-              id={id as Toolkits}
-              toolkit={toolkit as ClientToolkit}
-              selectedToolkits={selectedToolkits}
-              onAddToolkit={onAddToolkit}
-              onRemoveToolkit={onRemoveToolkit}
+    <div className="h-full overflow-hidden">
+      <TooltipProvider>
+        <div className="flex h-full max-h-full flex-col gap-2 overflow-hidden p-2">
+          <div className="relative">
+            <Search className="text-muted-foreground absolute top-2.5 left-2 size-4" />
+            <Input
+              placeholder="Search toolkits..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-8"
             />
-          );
-        })}
-      </VStack>
-    </TooltipProvider>
+          </div>
+          <VStack className="h-0 w-full flex-1 items-start overflow-y-auto">
+            {filteredToolkits.map(([id, toolkit]) => {
+              return (
+                <ToolkitItem
+                  key={id}
+                  id={id as Toolkits}
+                  toolkit={toolkit as ClientToolkit}
+                  selectedToolkits={selectedToolkits}
+                  onAddToolkit={onAddToolkit}
+                  onRemoveToolkit={onRemoveToolkit}
+                />
+              );
+            })}
+          </VStack>
+        </div>
+      </TooltipProvider>
+    </div>
   );
 };
 

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -96,13 +96,10 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
     }
   };
 
-  const handleConfigureSubmit = (parameters: Record<string, unknown>) => {
+  const handleConfigureSubmit = (toolkit: SelectedToolkit) => {
+    console.log("handleConfigureSubmit", toolkit);
     if (selectedToolkitForConfig) {
-      onAddToolkit({
-        id: selectedToolkitForConfig.id,
-        toolkit: selectedToolkitForConfig.toolkit,
-        parameters,
-      });
+      onAddToolkit(toolkit);
       setSelectedToolkitForConfig(null);
     }
   };

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -1,3 +1,9 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+import { Plus, Info, Search } from "lucide-react";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -10,16 +16,16 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Plus, Info } from "lucide-react";
 import { HStack, VStack } from "@/components/ui/stack";
+
+import { ClientToolkitConfigure } from "@/components/toolkit/toolkit-configure";
+
 import { clientToolkits } from "@/toolkits/toolkits/client";
+
 import type { ClientToolkit } from "@/toolkits/types";
 import type { Toolkits } from "@/toolkits/toolkits/shared";
-import { ClientToolkitConfigure } from "@/components/toolkit/toolkit-configure";
 import type { SelectedToolkit } from "./types";
-import { toolkitGroups } from "@/toolkits/toolkit-groups";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { Input } from "../ui/input";
 
 interface ToolkitListProps {
   selectedToolkits: SelectedToolkit[];
@@ -35,6 +41,17 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
+
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredToolkits = useMemo(() => {
+    return Object.entries(clientToolkits).filter(([, toolkit]) => {
+      return (
+        searchQuery.toLowerCase() === "" ||
+        toolkit.name.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+    });
+  }, [searchQuery]);
 
   useEffect(() => {
     const updatedToolkits = Object.entries(clientToolkits).filter(([id]) => {
@@ -58,31 +75,26 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
 
   return (
     <TooltipProvider>
-      <VStack className="w-full items-start gap-4">
-        {toolkitGroups.map((group) => {
+      <div className="relative mb-2">
+        <Search className="text-muted-foreground absolute top-2.5 left-2 size-4" />
+        <Input
+          placeholder="Search toolkits..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="pl-8"
+        />
+      </div>
+      <VStack className="w-full items-start">
+        {filteredToolkits.map(([id, toolkit]) => {
           return (
-            <VStack key={group.id} className="w-full items-start">
-              <HStack className="gap-2">
-                <group.icon className="size-4" />
-                <h3 className="font-bold">{group.name}</h3>
-              </HStack>
-              <div className="bg-muted/50 w-full rounded-md border">
-                {Object.entries(clientToolkits)
-                  .filter(([, toolkit]) => toolkit.type === group.id)
-                  .map(([id, toolkit]) => {
-                    return (
-                      <ToolkitItem
-                        key={id}
-                        id={id as Toolkits}
-                        toolkit={toolkit as ClientToolkit}
-                        selectedToolkits={selectedToolkits}
-                        onAddToolkit={onAddToolkit}
-                        onRemoveToolkit={onRemoveToolkit}
-                      />
-                    );
-                  })}
-              </div>
-            </VStack>
+            <ToolkitItem
+              key={id}
+              id={id as Toolkits}
+              toolkit={toolkit as ClientToolkit}
+              selectedToolkits={selectedToolkits}
+              onAddToolkit={onAddToolkit}
+              onRemoveToolkit={onRemoveToolkit}
+            />
           );
         })}
       </VStack>
@@ -153,7 +165,10 @@ const ToolkitItem = ({
   );
 
   return (
-    <div key={id} className="border-border/50 border-b p-2 last:border-b-0">
+    <div
+      key={id}
+      className="border-border/50 w-full border-b p-2 last:border-b-0"
+    >
       <div className="flex items-center justify-between gap-4">
         <div className="flex flex-1 flex-col">
           <HStack>

--- a/src/components/toolkit/toolkit-list.tsx
+++ b/src/components/toolkit/toolkit-list.tsx
@@ -16,7 +16,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { HStack, VStack } from "@/components/ui/stack";
+import { HStack } from "@/components/ui/stack";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Input } from "@/components/ui/input";
 
 import { ClientToolkitConfigure } from "@/components/toolkit/toolkit-configure";
 
@@ -25,13 +27,14 @@ import { clientToolkits } from "@/toolkits/toolkits/client";
 import type { ClientToolkit } from "@/toolkits/types";
 import type { Toolkits } from "@/toolkits/toolkits/shared";
 import type { SelectedToolkit } from "./types";
-import { Input } from "../ui/input";
 
 interface ToolkitListProps {
   selectedToolkits: SelectedToolkit[];
   onAddToolkit: (toolkit: SelectedToolkit) => void;
   onRemoveToolkit: (id: Toolkits) => void;
 }
+
+const toolkitItemHeight = 53;
 
 export const ToolkitList: React.FC<ToolkitListProps> = ({
   selectedToolkits,
@@ -74,9 +77,9 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
   }, [searchParams, onAddToolkit, selectedToolkits, router, pathname]);
 
   return (
-    <div className="h-full overflow-hidden">
+    <div className="overflow-hidden">
       <TooltipProvider>
-        <div className="flex h-full max-h-full flex-col gap-2 overflow-hidden p-2">
+        <div className="flex h-full max-h-full flex-col gap-2 overflow-hidden p-2 pb-0">
           <div className="relative">
             <Search className="text-muted-foreground absolute top-2.5 left-2 size-4" />
             <Input
@@ -86,7 +89,12 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
               className="pl-8"
             />
           </div>
-          <VStack className="h-0 w-full flex-1 items-start overflow-y-auto">
+          <ScrollArea
+            style={{
+              height: `${toolkitItemHeight * 3}px`,
+              paddingRight: "10px",
+            }}
+          >
             {filteredToolkits.length === 0 ? (
               <div className="flex-1 items-center justify-center">
                 <p className="text-muted-foreground text-sm">
@@ -107,7 +115,7 @@ export const ToolkitList: React.FC<ToolkitListProps> = ({
                 );
               })
             )}
-          </VStack>
+          </ScrollArea>
         </div>
       </TooltipProvider>
     </div>
@@ -150,7 +158,7 @@ const ToolkitItem = ({
           className="bg-transparent"
           type="button"
         >
-          Add
+          Enable
           <Plus className="size-4" />
         </Button>
       </PopoverTrigger>
@@ -171,7 +179,7 @@ const ToolkitItem = ({
       className="bg-transparent"
       type="button"
     >
-      Add
+      Enable
       <Plus className="size-4" />
     </Button>
   );

--- a/src/components/toolkit/toolkit-select.tsx
+++ b/src/components/toolkit/toolkit-select.tsx
@@ -34,7 +34,7 @@ import type { Toolkits } from "@/toolkits/toolkits/shared";
 interface Props {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  triggerButton: React.ReactNode;
+  children: React.ReactNode;
   toolkits: SelectedToolkit[];
   addToolkit: (toolkit: SelectedToolkit) => void;
   removeToolkit: (id: Toolkits) => void;
@@ -48,7 +48,7 @@ export const ToolkitSelect: React.FC<Props> = ({
   toolkits,
   addToolkit,
   removeToolkit,
-  triggerButton,
+  children,
 }) => {
   const isMobile = useIsMobile();
 
@@ -72,7 +72,7 @@ export const ToolkitSelect: React.FC<Props> = ({
   if (isMobile) {
     return (
       <Drawer open={isOpen} onOpenChange={onOpenChange}>
-        <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
+        <DrawerTrigger asChild>{children}</DrawerTrigger>
         <DrawerContent className="p-0">
           <DrawerHeader className="items-start px-3 pb-3">
             <DrawerTitle className="text-lg">Toolkit Selector</DrawerTitle>
@@ -88,7 +88,7 @@ export const ToolkitSelect: React.FC<Props> = ({
 
   return (
     <Popover open={isOpen} onOpenChange={onOpenChange}>
-      <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent
         className="w-xs overflow-hidden p-0 md:w-lg"
         align="start"
@@ -134,7 +134,7 @@ const WorkbenchSaveButton: React.FC<WorkbenchSaveButtonProps> = ({
   };
 
   return (
-    <div className="border-t p-2">
+    <div className="flex flex-col items-center gap-1 border-t p-2 text-center">
       <Button
         variant={"outline"}
         className="w-full bg-transparent"
@@ -142,8 +142,12 @@ const WorkbenchSaveButton: React.FC<WorkbenchSaveButtonProps> = ({
         disabled={isPending}
       >
         {isPending ? <Loader2 className="animate-spin" /> : <Save />}
-        Save
+        Update Workbench
       </Button>
+      <p className="text-muted-foreground text-xs">
+        You can proceed without saving if you do not want to change the default
+        workbench configuration.
+      </p>
     </div>
   );
 };

--- a/src/components/toolkit/toolkit-select.tsx
+++ b/src/components/toolkit/toolkit-select.tsx
@@ -1,0 +1,149 @@
+import { Loader2, Save } from "lucide-react";
+
+import { useRouter } from "next/navigation";
+
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+import { ToolkitList } from "@/components/toolkit/toolkit-list";
+
+import { api } from "@/trpc/react";
+
+import { useIsMobile } from "@/hooks/use-mobile";
+
+import { cn } from "@/lib/utils";
+
+import type { Workbench } from "@prisma/client";
+import type { SelectedToolkit } from "./types";
+import type { Toolkits } from "@/toolkits/toolkits/shared";
+
+interface Props {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  triggerButton: React.ReactNode;
+  toolkits: SelectedToolkit[];
+  addToolkit: (toolkit: SelectedToolkit) => void;
+  removeToolkit: (id: Toolkits) => void;
+  workbench?: Workbench | undefined;
+}
+
+export const ToolkitSelect: React.FC<Props> = ({
+  isOpen,
+  onOpenChange,
+  workbench,
+  toolkits,
+  addToolkit,
+  removeToolkit,
+  triggerButton,
+}) => {
+  const isMobile = useIsMobile();
+
+  const content = (
+    <div className={cn("w-full max-w-full")}>
+      <ToolkitList
+        selectedToolkits={toolkits}
+        onAddToolkit={addToolkit}
+        onRemoveToolkit={removeToolkit}
+      />
+      {workbench !== undefined && (
+        <WorkbenchSaveButton
+          workbench={workbench}
+          toolkits={toolkits}
+          setIsOpen={onOpenChange}
+        />
+      )}
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={isOpen} onOpenChange={onOpenChange}>
+        <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
+        <DrawerContent className="p-0">
+          <DrawerHeader className="items-start px-3 pb-3">
+            <DrawerTitle className="text-lg">Toolkit Selector</DrawerTitle>
+            <DrawerDescription>
+              Add tools to give the model more capabilities
+            </DrawerDescription>
+          </DrawerHeader>
+          {content}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Popover open={isOpen} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+      <PopoverContent
+        className="w-xs overflow-hidden p-0 md:w-lg"
+        align="start"
+        sideOffset={8}
+      >
+        {content}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+interface WorkbenchSaveButtonProps {
+  workbench: Workbench;
+  toolkits: SelectedToolkit[];
+  setIsOpen: (open: boolean) => void;
+}
+
+const WorkbenchSaveButton: React.FC<WorkbenchSaveButtonProps> = ({
+  workbench,
+  toolkits,
+  setIsOpen,
+}) => {
+  const router = useRouter();
+
+  const { mutate: updateWorkbench, isPending } =
+    api.workbenches.updateWorkbench.useMutation({
+      onSuccess: () => {
+        toast.success("Workbench updated successfully");
+        router.refresh();
+        setIsOpen(false);
+      },
+    });
+
+  const handleSave = () => {
+    if (workbench) {
+      updateWorkbench({
+        id: workbench.id,
+        name: workbench.name,
+        systemPrompt: workbench.systemPrompt,
+        toolkitIds: toolkits.map((toolkit) => toolkit.id),
+      });
+    }
+  };
+
+  return (
+    <div className="border-t p-2">
+      <Button
+        variant={"outline"}
+        className="w-full bg-transparent"
+        onClick={handleSave}
+        disabled={isPending}
+      >
+        {isPending ? <Loader2 className="animate-spin" /> : <Save />}
+        Save
+      </Button>
+    </div>
+  );
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  wrapperClassName,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input> & {
+  placeholder?: string;
+  wrapperClassName?: string;
+}) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className={cn(
+        "flex h-9 items-center gap-2 border-b px-3",
+        wrapperClassName,
+      )}
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+
+import { cn } from "@/lib/utils";
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar forceMount className="opacity-50" />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };

--- a/src/toolkits/lib/auth-required-dialog.tsx
+++ b/src/toolkits/lib/auth-required-dialog.tsx
@@ -40,18 +40,22 @@ export const AuthRequiredDialog: React.FC<Props> = ({
             <Code className="size-4" />
             <Icon className="size-12" />
           </HStack>
-          <VStack className="gap-0">
+          <VStack className="gap-1">
             <DialogTitle>{title}</DialogTitle>
-            <DialogDescription>{description}</DialogDescription>
+            <DialogDescription className="text-center">
+              {description}
+            </DialogDescription>
           </VStack>
         </DialogHeader>
         {content}
-        <DialogFooter className="justify-center md:justify-center">
-          <p className="text-muted-foreground max-w-xs text-center text-xs">
-            Your configuration will be saved securely by Toolkit and can be
-            deleted at any time.
-          </p>
-        </DialogFooter>
+        {content && (
+          <DialogFooter className="justify-center md:justify-center">
+            <p className="text-muted-foreground max-w-xs text-center text-xs">
+              Your configuration will be saved securely by Toolkit and can be
+              deleted at any time.
+            </p>
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/toolkits/lib/auth-required-dialog.tsx
+++ b/src/toolkits/lib/auth-required-dialog.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+
+import { Code } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Logo } from "@/components/ui/logo";
+import { HStack, VStack } from "@/components/ui/stack";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  Icon: React.FC<{ className?: string }>;
+  title: string;
+  description: string;
+  content: React.ReactNode;
+}
+
+export const AuthRequiredDialog: React.FC<Props> = ({
+  isOpen,
+  onOpenChange,
+  Icon,
+  title,
+  description,
+  content,
+}) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader className="flex flex-col items-center gap-8 text-center">
+          <HStack className="gap-4">
+            <Logo className="size-12" />
+            <Code className="size-4" />
+            <Icon className="size-12" />
+          </HStack>
+          <VStack className="gap-0">
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </VStack>
+        </DialogHeader>
+        {content}
+        <DialogFooter className="justify-center md:justify-center">
+          <p className="text-muted-foreground max-w-xs text-center text-xs">
+            Your configuration will be saved securely by Toolkit and can be
+            deleted at any time.
+          </p>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+interface AuthButtonProps {
+  onClick: () => void;
+  children: string;
+}
+
+export const AuthButton: React.FC<AuthButtonProps> = ({
+  onClick,
+  children,
+}) => {
+  return (
+    <Button size="lg" onClick={onClick} className="user-message">
+      {children}
+    </Button>
+  );
+};

--- a/src/toolkits/toolkits/google-calendar/client.tsx
+++ b/src/toolkits/toolkits/google-calendar/client.tsx
@@ -56,8 +56,8 @@ export const googleCalendarClientToolkit = createClientToolkit(
               onSelect={() => setIsPrivateBetaDialogOpen(true)}
             />
             <AuthRequiredDialog
-              isOpen={isAuthRequiredDialogOpen}
-              onOpenChange={setIsAuthRequiredDialogOpen}
+              isOpen={isPrivateBetaDialogOpen}
+              onOpenChange={setIsPrivateBetaDialogOpen}
               Icon={SiGooglecalendar}
               title="Beta Access Required"
               description="We need to add you as a test user on Google Cloud for us to request sensitive OAuth scopes. Please contact @jsonhedman on X to request access."
@@ -67,60 +67,8 @@ export const googleCalendarClientToolkit = createClientToolkit(
         );
       }
 
-      if (!account) {
-        return (
-          <>
-            <Item
-              isLoading={false}
-              onSelect={() => {
-                void signIn(
-                  "google",
-                  {
-                    callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
-                  },
-                  {
-                    prompt: "consent",
-                    access_type: "offline",
-                    response_type: "code",
-                    include_granted_scopes: true,
-                    scope: `openid email profile ${calendarScope}`,
-                  },
-                );
-              }}
-            />
-            <AuthRequiredDialog
-              isOpen={isPrivateBetaDialogOpen}
-              onOpenChange={setIsPrivateBetaDialogOpen}
-              Icon={SiGooglecalendar}
-              title="Connect your Google Calendar"
-              description="This will request read and write access to your Google Calendar."
-              content={
-                <AuthButton
-                  onClick={() => {
-                    void signIn(
-                      "google",
-                      {
-                        callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
-                      },
-                      {
-                        prompt: "consent",
-                        access_type: "offline",
-                        response_type: "code",
-                        include_granted_scopes: true,
-                        scope: `openid email profile ${calendarScope}`,
-                      },
-                    );
-                  }}
-                >
-                  Connect your Google Calendar
-                </AuthButton>
-              }
-            />
-          </>
-        );
-      }
-
       if (!account?.scope?.includes(calendarScope)) {
+        const isMissingAccount = !account;
         return (
           <>
             <Item
@@ -146,12 +94,16 @@ export const googleCalendarClientToolkit = createClientToolkit(
                         access_type: "offline",
                         response_type: "code",
                         include_granted_scopes: true,
-                        scope: `${account?.scope} ${calendarScope}`,
+                        scope: isMissingAccount
+                          ? `openid email profile ${calendarScope}`
+                          : `${account?.scope} ${calendarScope}`,
                       },
                     );
                   }}
                 >
-                  Grant Access
+                  {isMissingAccount
+                    ? "Connect your Google Calendar"
+                    : "Grant Access"}
                 </AuthButton>
               }
             />

--- a/src/toolkits/toolkits/google-calendar/client.tsx
+++ b/src/toolkits/toolkits/google-calendar/client.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { GoogleCalendarTools } from "./tools";
 import { createClientToolkit } from "@/toolkits/create-toolkit";
 import { baseGoogleCalendarToolkitConfig } from "./base";
@@ -10,19 +12,15 @@ import {
 } from "./tools/client";
 import { api } from "@/trpc/react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { signIn } from "next-auth/react";
-import { Loader2 } from "lucide-react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import Link from "next/link";
 import { SiGooglecalendar } from "@icons-pack/react-simple-icons";
 import { ToolkitGroups } from "@/toolkits/types";
 import { Toolkits } from "../shared";
+import {
+  AuthButton,
+  AuthRequiredDialog,
+} from "@/toolkits/lib/auth-required-dialog";
+import { useState } from "react";
 
 const calendarScope = "https://www.googleapis.com/auth/calendar";
 
@@ -33,7 +31,7 @@ export const googleCalendarClientToolkit = createClientToolkit(
     description: "Find availability and schedule meetings",
     icon: SiGooglecalendar,
     form: null,
-    addToolkitWrapper: ({ children }) => {
+    Wrapper: ({ Item }) => {
       const { data: account, isLoading: isLoadingAccount } =
         api.accounts.getAccountByProvider.useQuery("google");
 
@@ -42,98 +40,129 @@ export const googleCalendarClientToolkit = createClientToolkit(
           feature: "google-calendar",
         });
 
+      const [isPrivateBetaDialogOpen, setIsPrivateBetaDialogOpen] =
+        useState(false);
+      const [isAuthRequiredDialogOpen, setIsAuthRequiredDialogOpen] =
+        useState(false);
+
       if (isLoadingAccount || isLoadingAccess) {
-        return (
-          <Button
-            variant="outline"
-            size="sm"
-            disabled
-            className="bg-transparent"
-          >
-            <Loader2 className="size-4 animate-spin" />
-          </Button>
-        );
+        return <Item isLoading={true} />;
       }
 
       if (!hasAccess) {
         return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                <Badge variant="outline">Private Beta</Badge>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs text-center">
-                We need to add you as a test user on Google Cloud for us to
-                request sensitive OAuth scopes. <br />
-                <br /> Please contact{" "}
-                <Link
-                  href="https://x.com/jsonhedman"
-                  target="_blank"
-                  className="underline"
-                >
-                  @jsonhedman
-                </Link>{" "}
-                on X to request access.
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <>
+            <Item
+              isLoading={isLoadingAccount || isLoadingAccess}
+              onSelect={() => setIsPrivateBetaDialogOpen(true)}
+            />
+            <AuthRequiredDialog
+              isOpen={isAuthRequiredDialogOpen}
+              onOpenChange={setIsAuthRequiredDialogOpen}
+              Icon={SiGooglecalendar}
+              title="Beta Access Required"
+              description="We need to add you as a test user on Google Cloud for us to request sensitive OAuth scopes. Please contact @jsonhedman on X to request access."
+              content={null}
+            />
+          </>
         );
       }
 
       if (!account) {
         return (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              void signIn(
-                "google",
-                {
-                  callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
-                },
-                {
-                  prompt: "consent",
-                  access_type: "offline",
-                  response_type: "code",
-                  include_granted_scopes: true,
-                  scope: `openid email profile ${calendarScope}`,
-                },
-              );
-            }}
-            className="bg-transparent"
-          >
-            Connect
-          </Button>
+          <>
+            <Item
+              isLoading={false}
+              onSelect={() => {
+                void signIn(
+                  "google",
+                  {
+                    callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
+                  },
+                  {
+                    prompt: "consent",
+                    access_type: "offline",
+                    response_type: "code",
+                    include_granted_scopes: true,
+                    scope: `openid email profile ${calendarScope}`,
+                  },
+                );
+              }}
+            />
+            <AuthRequiredDialog
+              isOpen={isPrivateBetaDialogOpen}
+              onOpenChange={setIsPrivateBetaDialogOpen}
+              Icon={SiGooglecalendar}
+              title="Connect your Google Calendar"
+              description="This will request read and write access to your Google Calendar."
+              content={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    void signIn(
+                      "google",
+                      {
+                        callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
+                      },
+                      {
+                        prompt: "consent",
+                        access_type: "offline",
+                        response_type: "code",
+                        include_granted_scopes: true,
+                        scope: `openid email profile ${calendarScope}`,
+                      },
+                    );
+                  }}
+                >
+                  Connect your Google Calendar
+                </Button>
+              }
+            />
+          </>
         );
       }
 
       if (!account?.scope?.includes(calendarScope)) {
         return (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              void signIn(
-                "google",
-                {
-                  callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
-                },
-                {
-                  prompt: "consent",
-                  access_type: "offline",
-                  response_type: "code",
-                  include_granted_scopes: true,
-                  scope: `${account?.scope} ${calendarScope}`,
-                },
-              );
-            }}
-          >
-            Grant Access
-          </Button>
+          <>
+            <Item
+              isLoading={false}
+              onSelect={() => setIsAuthRequiredDialogOpen(true)}
+            />
+            <AuthRequiredDialog
+              isOpen={isAuthRequiredDialogOpen}
+              onOpenChange={setIsAuthRequiredDialogOpen}
+              Icon={SiGooglecalendar}
+              title="Connect your Google Calendar"
+              description="This will request read and write access to your Google Calendar."
+              content={
+                <AuthButton
+                  onClick={() => {
+                    void signIn(
+                      "google",
+                      {
+                        callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
+                      },
+                      {
+                        prompt: "consent",
+                        access_type: "offline",
+                        response_type: "code",
+                        include_granted_scopes: true,
+                        scope: `${account?.scope} ${calendarScope}`,
+                      },
+                    );
+                  }}
+                >
+                  Grant Access
+                </AuthButton>
+              }
+            />
+          </>
         );
       }
 
-      return children;
+      return <Item isLoading={false} />;
     },
     type: ToolkitGroups.DataSource,
   },

--- a/src/toolkits/toolkits/google-calendar/client.tsx
+++ b/src/toolkits/toolkits/google-calendar/client.tsx
@@ -11,7 +11,6 @@ import {
   googleCalendarSearchEventsToolConfigClient,
 } from "./tools/client";
 import { api } from "@/trpc/react";
-import { Button } from "@/components/ui/button";
 import { signIn } from "next-auth/react";
 import { SiGooglecalendar } from "@icons-pack/react-simple-icons";
 import { ToolkitGroups } from "@/toolkits/types";
@@ -96,9 +95,7 @@ export const googleCalendarClientToolkit = createClientToolkit(
               title="Connect your Google Calendar"
               description="This will request read and write access to your Google Calendar."
               content={
-                <Button
-                  variant="outline"
-                  size="sm"
+                <AuthButton
                   onClick={() => {
                     void signIn(
                       "google",
@@ -116,7 +113,7 @@ export const googleCalendarClientToolkit = createClientToolkit(
                   }}
                 >
                   Connect your Google Calendar
-                </Button>
+                </AuthButton>
               }
             />
           </>

--- a/src/toolkits/toolkits/google-drive/client.tsx
+++ b/src/toolkits/toolkits/google-drive/client.tsx
@@ -1,25 +1,27 @@
-import { GoogleDriveTools } from "./tools";
+"use client";
+
+import { useState } from "react";
+
+import { signIn } from "next-auth/react";
+
+import { api } from "@/trpc/react";
+
 import { createClientToolkit } from "@/toolkits/create-toolkit";
+
+import { Toolkits } from "../shared";
 import { baseGoogleDriveToolkitConfig } from "./base";
 import {
   googleDriveSearchFilesToolConfigClient,
   googleDriveReadFileToolConfigClient,
 } from "./tools/client";
-import { api } from "@/trpc/react";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { signIn } from "next-auth/react";
-import { Loader2 } from "lucide-react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import Link from "next/link";
+import { GoogleDriveTools } from "./tools";
+
 import { SiGoogledrive } from "@icons-pack/react-simple-icons";
 import { ToolkitGroups } from "@/toolkits/types";
-import { Toolkits } from "../shared";
+import {
+  AuthButton,
+  AuthRequiredDialog,
+} from "@/toolkits/lib/auth-required-dialog";
 
 const driveScope = "https://www.googleapis.com/auth/drive.readonly";
 
@@ -30,108 +32,136 @@ export const googleDriveClientToolkit = createClientToolkit(
     description: "Search and read files from your Google Drive.",
     icon: SiGoogledrive,
     form: null,
-    addToolkitWrapper: ({ children }) => {
+    Wrapper: ({ Item }) => {
       const { data: account, isLoading: isLoadingAccount } =
         api.accounts.getAccountByProvider.useQuery("google");
 
       const { data: hasAccess, isLoading: isLoadingAccess } =
         api.features.hasFeature.useQuery({
-          feature: "google-drive",
+          feature: "google-calendar",
         });
 
+      const [isPrivateBetaDialogOpen, setIsPrivateBetaDialogOpen] =
+        useState(false);
+      const [isAuthRequiredDialogOpen, setIsAuthRequiredDialogOpen] =
+        useState(false);
+
       if (isLoadingAccount || isLoadingAccess) {
-        return (
-          <Button
-            variant="outline"
-            size="sm"
-            disabled
-            className="bg-transparent"
-          >
-            <Loader2 className="size-4 animate-spin" />
-          </Button>
-        );
+        return <Item isLoading={true} />;
       }
 
       if (!hasAccess) {
         return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                <Badge variant="outline">Private Beta</Badge>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs text-center">
-                We need to add you as a test user on Google Cloud for us to
-                request sensitive OAuth scopes. <br />
-                <br /> Please contact{" "}
-                <Link
-                  href="https://x.com/jsonhedman"
-                  target="_blank"
-                  className="underline"
-                >
-                  @jsonhedman
-                </Link>{" "}
-                on X to request access.
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <>
+            <Item
+              isLoading={isLoadingAccount || isLoadingAccess}
+              onSelect={() => setIsPrivateBetaDialogOpen(true)}
+            />
+            <AuthRequiredDialog
+              isOpen={isAuthRequiredDialogOpen}
+              onOpenChange={setIsAuthRequiredDialogOpen}
+              Icon={SiGoogledrive}
+              title="Beta Access Required"
+              description="We need to add you as a test user on Google Cloud for us to request sensitive OAuth scopes. Please contact @jsonhedman on X to request access."
+              content={null}
+            />
+          </>
         );
       }
 
       if (!account) {
         return (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              void signIn(
-                "google",
-                {
-                  callbackUrl: `${window.location.href}?${Toolkits.GoogleDrive}=true`,
-                },
-                {
-                  prompt: "consent",
-                  access_type: "offline",
-                  response_type: "code",
-                  include_granted_scopes: true,
-                  scope: `openid email profile ${driveScope}`,
-                },
-              );
-            }}
-            className="bg-transparent"
-          >
-            Connect
-          </Button>
+          <>
+            <Item
+              isLoading={false}
+              onSelect={() => {
+                void signIn(
+                  "google",
+                  {
+                    callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
+                  },
+                  {
+                    prompt: "consent",
+                    access_type: "offline",
+                    response_type: "code",
+                    include_granted_scopes: true,
+                    scope: `openid email profile ${driveScope}`,
+                  },
+                );
+              }}
+            />
+            <AuthRequiredDialog
+              isOpen={isPrivateBetaDialogOpen}
+              onOpenChange={setIsPrivateBetaDialogOpen}
+              Icon={SiGoogledrive}
+              title="Connect your Google Calendar"
+              description="This will request read and write access to your Google Calendar."
+              content={
+                <AuthButton
+                  onClick={() => {
+                    void signIn(
+                      "google",
+                      {
+                        callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
+                      },
+                      {
+                        prompt: "consent",
+                        access_type: "offline",
+                        response_type: "code",
+                        include_granted_scopes: true,
+                        scope: `openid email profile ${driveScope}`,
+                      },
+                    );
+                  }}
+                >
+                  Connect your Google Calendar
+                </AuthButton>
+              }
+            />
+          </>
         );
       }
 
       if (!account?.scope?.includes(driveScope)) {
         return (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              void signIn(
-                "google",
-                {
-                  callbackUrl: `${window.location.href}?${Toolkits.GoogleDrive}=true`,
-                },
-                {
-                  prompt: "consent",
-                  access_type: "offline",
-                  response_type: "code",
-                  include_granted_scopes: true,
-                  scope: `${account?.scope} ${driveScope}`,
-                },
-              );
-            }}
-            className="bg-transparent"
-          >
-            Grant Access
-          </Button>
+          <>
+            <Item
+              isLoading={false}
+              onSelect={() => setIsAuthRequiredDialogOpen(true)}
+            />
+            <AuthRequiredDialog
+              isOpen={isAuthRequiredDialogOpen}
+              onOpenChange={setIsAuthRequiredDialogOpen}
+              Icon={SiGoogledrive}
+              title="Connect your Google Drive"
+              description="This will request read access to your Google Drive."
+              content={
+                <AuthButton
+                  onClick={() => {
+                    void signIn(
+                      "google",
+                      {
+                        callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
+                      },
+                      {
+                        prompt: "consent",
+                        access_type: "offline",
+                        response_type: "code",
+                        include_granted_scopes: true,
+                        scope: `${account?.scope} ${driveScope}`,
+                      },
+                    );
+                  }}
+                >
+                  Grant Access
+                </AuthButton>
+              }
+            />
+          </>
         );
       }
 
-      return children;
+      return <Item isLoading={false} />;
     },
     type: ToolkitGroups.KnowledgeBase,
   },

--- a/src/toolkits/toolkits/google-drive/client.tsx
+++ b/src/toolkits/toolkits/google-drive/client.tsx
@@ -38,7 +38,7 @@ export const googleDriveClientToolkit = createClientToolkit(
 
       const { data: hasAccess, isLoading: isLoadingAccess } =
         api.features.hasFeature.useQuery({
-          feature: "google-calendar",
+          feature: "google-drive",
         });
 
       const [isPrivateBetaDialogOpen, setIsPrivateBetaDialogOpen] =
@@ -58,8 +58,8 @@ export const googleDriveClientToolkit = createClientToolkit(
               onSelect={() => setIsPrivateBetaDialogOpen(true)}
             />
             <AuthRequiredDialog
-              isOpen={isAuthRequiredDialogOpen}
-              onOpenChange={setIsAuthRequiredDialogOpen}
+              isOpen={isPrivateBetaDialogOpen}
+              onOpenChange={setIsPrivateBetaDialogOpen}
               Icon={SiGoogledrive}
               title="Beta Access Required"
               description="We need to add you as a test user on Google Cloud for us to request sensitive OAuth scopes. Please contact @jsonhedman on X to request access."
@@ -69,60 +69,8 @@ export const googleDriveClientToolkit = createClientToolkit(
         );
       }
 
-      if (!account) {
-        return (
-          <>
-            <Item
-              isLoading={false}
-              onSelect={() => {
-                void signIn(
-                  "google",
-                  {
-                    callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
-                  },
-                  {
-                    prompt: "consent",
-                    access_type: "offline",
-                    response_type: "code",
-                    include_granted_scopes: true,
-                    scope: `openid email profile ${driveScope}`,
-                  },
-                );
-              }}
-            />
-            <AuthRequiredDialog
-              isOpen={isPrivateBetaDialogOpen}
-              onOpenChange={setIsPrivateBetaDialogOpen}
-              Icon={SiGoogledrive}
-              title="Connect your Google Calendar"
-              description="This will request read and write access to your Google Calendar."
-              content={
-                <AuthButton
-                  onClick={() => {
-                    void signIn(
-                      "google",
-                      {
-                        callbackUrl: `${window.location.href}?${Toolkits.GoogleCalendar}=true`,
-                      },
-                      {
-                        prompt: "consent",
-                        access_type: "offline",
-                        response_type: "code",
-                        include_granted_scopes: true,
-                        scope: `openid email profile ${driveScope}`,
-                      },
-                    );
-                  }}
-                >
-                  Connect your Google Calendar
-                </AuthButton>
-              }
-            />
-          </>
-        );
-      }
-
       if (!account?.scope?.includes(driveScope)) {
+        const isMissingAccount = !account;
         return (
           <>
             <Item
@@ -134,7 +82,11 @@ export const googleDriveClientToolkit = createClientToolkit(
               onOpenChange={setIsAuthRequiredDialogOpen}
               Icon={SiGoogledrive}
               title="Connect your Google Drive"
-              description="This will request read access to your Google Drive."
+              description={
+                isMissingAccount
+                  ? "This will request read-only access to your Google Drive."
+                  : "This will request read access to your Google Drive."
+              }
               content={
                 <AuthButton
                   onClick={() => {
@@ -148,12 +100,16 @@ export const googleDriveClientToolkit = createClientToolkit(
                         access_type: "offline",
                         response_type: "code",
                         include_granted_scopes: true,
-                        scope: `${account?.scope} ${driveScope}`,
+                        scope: isMissingAccount
+                          ? `openid email profile ${driveScope}`
+                          : `${account?.scope} ${driveScope}`,
                       },
                     );
                   }}
                 >
-                  Grant Access
+                  {isMissingAccount
+                    ? "Connect your Google Drive"
+                    : "Grant Access"}
                 </AuthButton>
               }
             />

--- a/src/toolkits/types.ts
+++ b/src/toolkits/types.ts
@@ -23,8 +23,8 @@ export type ClientToolkitConifg<Parameters extends ZodRawShape = ZodRawShape> =
       parameters: z.infer<ZodObject<Parameters>>;
       setParameters: (parameters: z.infer<ZodObject<Parameters>>) => void;
     }> | null;
-    addToolkitWrapper?: React.ComponentType<{
-      children: React.ReactNode;
+    Wrapper: React.FC<{
+      Item: React.FC<{ isLoading: boolean; onSelect?: () => void }>;
     }>;
     type: ToolkitGroups;
   };

--- a/src/toolkits/types.ts
+++ b/src/toolkits/types.ts
@@ -23,10 +23,10 @@ export type ClientToolkitConifg<Parameters extends ZodRawShape = ZodRawShape> =
       parameters: z.infer<ZodObject<Parameters>>;
       setParameters: (parameters: z.infer<ZodObject<Parameters>>) => void;
     }> | null;
-    Wrapper: React.FC<{
+    type: ToolkitGroups;
+    Wrapper?: React.FC<{
       Item: React.FC<{ isLoading: boolean; onSelect?: () => void }>;
     }>;
-    type: ToolkitGroups;
   };
 
 export type ClientToolkit<


### PR DESCRIPTION
Update the toolkit select UI to be a command popover with modals for extra auth / parameterization.

Will become more important as we onboard hundreds of toolkits. This will provide a way to easily search and filter.

<img width="616" height="413" alt="image" src="https://github.com/user-attachments/assets/0a09937d-0310-497f-b91e-f4f3137284e3" />

Also a command on mobile. This frees up a lot of screen real estate and feels much cleaner (thanks @fmhall)


<img width="473" height="763" alt="image" src="https://github.com/user-attachments/assets/cab5952d-4f49-432a-ab7e-43dce852bda2" />

