### PR TITLE
Fix Notion Auth

### DIFF
--- a/src/server/auth/providers.ts
+++ b/src/server/auth/providers.ts
@@ -61,6 +61,17 @@ export const providers: (
           clientId: env.AUTH_NOTION_ID,
           clientSecret: env.AUTH_NOTION_SECRET,
           redirectUri: `${env.NEXTAUTH_URL}/api/auth/callback/notion`,
+          token: {
+            conform: async (response: Response) => {
+              const body = (await response.json()) as {
+                refresh_token?: string;
+              };
+              if (body?.refresh_token === null) {
+                delete body.refresh_token;
+              }
+              return new Response(JSON.stringify(body), response);
+            },
+          },
         }),
       ]
     : []),


### PR DESCRIPTION
Notion returns `refresh_token: null` in its OAuth response, but NextAuth expects `string | undefined`.

There is an open issue regarding this [here](https://github.com/nextauthjs/next-auth/issues/13109) and an unmerged PR with a fix [here](https://github.com/nextauthjs/next-auth/pull/13110).

I grabbed the patch and put it directly into our notion provider.

Thank you to Steak in the Discord for finding this one!