### PR TITLE
force the use of pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ We also have a [Discord Community](https://discord.gg/cnNBsSfY) to discuss all t
 
 ### Prerequisites
 
-- **Node.js** 18+
-- **pnpm** (recommended), npm, bun, or yarn
+- **Node.js** 18+ - if you do not have node installed, install it [here](https://nodejs.org/en/download)
+- **pnpm** - if you do not have pnpm installed, run `npm i -g pnpm`
 - **Docker** or **Podman**
   - You can install Docker Desktop for free [here](https://www.docker.com/products/docker-desktop/)
 
@@ -32,12 +32,6 @@ cd toolkit.dev
 
 # Run the automated setup
 pnpm dev
-# or
-npm run dev
-# or
-yarn dev
-# or
-bun dev
 ```
 
 The setup script will:
@@ -65,15 +59,6 @@ This will set up your `.env.local`, install dependencies, start the required Doc
 
 ```bash
 pnpm dev
-
-# or
-npm run dev
-
-# or
-yarn dev
-
-# or
-bun dev
 ```
 
 #### 3) [OPTIONAL] Add an OpenRouter Key

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "db:push": "dotenv -e .env.local -- prisma db push",
     "db:studio": "dotenv -e .env.local -- prisma studio",
     "db:reset": "dotenv -e .env.local -- prisma migrate reset",
-    "dev": "npx tsx setup/index.ts && next dev --turbo",
+    "dev": "pnpm dlx tsx setup/index.ts && next dev --turbo",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "postinstall": "prisma generate",
@@ -130,5 +130,14 @@
   "ct3aMetadata": {
     "initVersion": "7.39.3"
   },
-  "packageManager": "pnpm@10.3.0"
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
+  }
 }

--- a/setup/utils.ts
+++ b/setup/utils.ts
@@ -87,26 +87,14 @@ export function getServiceUrl(service: string): string {
 export function getPackageManager(): string {
   if (commandExists("pnpm")) {
     return "pnpm";
-  } else if (commandExists("yarn")) {
-    return "yarn";
-  } else if (commandExists("bun")) {
-    return "bun";
-  } else if (commandExists("npm")) {
-    return "npm";
   }
-  throw new Error("No package manager found");
+  throw new Error("pnpm is not installed. run `npm i -g pnpm`");
 }
 
 export function getPackageRunner(): string {
   const packageManager = getPackageManager();
   if (packageManager === "pnpm") {
     return "pnpm dlx";
-  } else if (packageManager === "yarn") {
-    return "yarn dlx";
-  } else if (packageManager === "bun") {
-    return "bunx";
-  } else if (packageManager === "npm") {
-    return "npx";
   }
   throw new Error("No package runner found");
 }


### PR DESCRIPTION
`npm` and `yarn` do not work as they do not resolve peer dependencies correctly

maintaining support for all package managers will be too much overhead

this forces devs to use pnpm and wont run any commands if `pnpm` is not used