### PR TITLE
only use redirect proxy in dev

### DIFF
--- a/src/server/auth/providers.ts
+++ b/src/server/auth/providers.ts
@@ -96,7 +96,9 @@ export const providers: (
             "https://accounts.spotify.com/authorize?scope=user-read-email+playlist-read-private+playlist-read-collaborative+user-library-read",
           allowDangerousEmailAccountLinking: true,
           // Spotify does not allow localhost redirects, so we need to use the IP of localhost instead
-          redirectProxyUrl: `http://127.0.0.1:3000/api/auth`,
+          redirectProxyUrl: IS_DEVELOPMENT
+            ? `http://127.0.0.1:3000/api/auth`
+            : undefined,
         }),
       ]
     : []),


### PR DESCRIPTION
For some reason I removed the redirect proxy while updating spotify toolkit