### PR TITLE
feat: add OpenRouter headers for app attribution

### DIFF
--- a/src/ai/language/generate.ts
+++ b/src/ai/language/generate.ts
@@ -2,12 +2,19 @@ import { generateText as generateTextAi, streamText as streamTextAi } from "ai";
 
 import { openrouter } from "@openrouter/ai-sdk-provider";
 
+// Add headers directly to the OpenRouter client
+const headers = {
+  "HTTP-Referer": "https://toolkit.dev",
+  "X-Title": "Toolkit.dev",
+};
+
 export const generateText = (
   model: `${string}/${string}`,
   params: Omit<Parameters<typeof generateTextAi>[0], "model">,
 ) => {
   return generateTextAi({
     model: openrouter(model),
+    headers,
     ...params,
   });
 };
@@ -18,6 +25,7 @@ export const streamText = (
 ) => {
   return streamTextAi({
     model: openrouter(model),
+    headers,
     ...params,
   });
 };

--- a/src/ai/language/models/openrouter.ts
+++ b/src/ai/language/models/openrouter.ts
@@ -22,6 +22,26 @@ const openRouterModelData: Omit<LanguageModel, "provider">[] = [
     contextLength: 200000, // Using a high value since it can route to models with large context
     isNew: true,
   },
+  {
+    name: "Horizon Alpha",
+    modelId: "horizon-alpha",
+    description:
+      "A cloaked model provided to the community to gather feedback. Supports vision and long-context tasks.",
+    capabilities: [
+      LanguageModelCapability.Vision,
+      LanguageModelCapability.ToolCalling,
+      LanguageModelCapability.Reasoning,
+      LanguageModelCapability.Pdf,
+    ],
+    bestFor: [
+      "Image analysis",
+      "Long-context tasks",
+      "Community feedback",
+      "General purpose AI",
+    ],
+    contextLength: 256000,
+    isNew: true,
+  },
 ];
 
 export const openRouterModels: LanguageModel[] = openRouterModelData.map(


### PR DESCRIPTION
- Added `HTTP-Referer` and `X-Title` headers to OpenRouter API requests in `src/ai/language/generate.ts`
- Headers are set to:
  - `HTTP-Referer`: "https://toolkit.dev"
  - `X-Title`: "Toolkit.dev"