### PR TITLE
Feat/horizon alpha integration

### DIFF
--- a/src/ai/language/generate.ts
+++ b/src/ai/language/generate.ts
@@ -2,12 +2,19 @@ import { generateText as generateTextAi, streamText as streamTextAi } from "ai";
 
 import { openrouter } from "@openrouter/ai-sdk-provider";
 
+// Add headers directly to the OpenRouter client
+const headers = {
+  "HTTP-Referer": "https://toolkit.dev",
+  "X-Title": "Toolkit.dev",
+};
+
 export const generateText = (
   model: `${string}/${string}`,
   params: Omit<Parameters<typeof generateTextAi>[0], "model">,
 ) => {
   return generateTextAi({
     model: openrouter(model),
+    headers,
     ...params,
   });
 };
@@ -18,6 +25,7 @@ export const streamText = (
 ) => {
   return streamTextAi({
     model: openrouter(model),
+    headers,
     ...params,
   });
 };

--- a/src/ai/language/models/openrouter.ts
+++ b/src/ai/language/models/openrouter.ts
@@ -22,6 +22,24 @@ const openRouterModelData: Omit<LanguageModel, "provider">[] = [
     contextLength: 200000, // Using a high value since it can route to models with large context
     isNew: true,
   },
+  {
+    name: "Horizon Alpha",
+    modelId: "horizon-alpha",
+    description:
+      "A cloaked model provided to the community for feedback. Supports vision and long-context tasks.",
+    capabilities: [
+      LanguageModelCapability.Vision,
+      LanguageModelCapability.ToolCalling,
+    ],
+    bestFor: [
+      "Vision tasks",
+      "Long-context processing",
+      "General purpose",
+      "Community feedback model",
+    ],
+    contextLength: 256000,
+    isNew: true,
+  },
 ];
 
 export const openRouterModels: LanguageModel[] = openRouterModelData.map(

--- a/src/app/_contexts/chat-context.tsx
+++ b/src/app/_contexts/chat-context.tsx
@@ -22,7 +22,7 @@ import { LanguageModelCapability } from "@/ai/language/types";
 
 import { clientToolkits } from "@/toolkits/toolkits/client";
 
-import { anthropicModels } from "@/ai/language/models/anthropic";
+import { languageModels } from "@/ai/language";
 
 import { clientCookieUtils } from "@/lib/cookies/client";
 import { generateUUID } from "@/lib/utils";
@@ -42,7 +42,7 @@ import type { PersistedToolkit } from "@/lib/cookies/types";
 import type { ImageModel } from "@/ai/image/types";
 import type { LanguageModel } from "@/ai/language/types";
 
-const DEFAULT_CHAT_MODEL = anthropicModels[0]!;
+const DEFAULT_CHAT_MODEL = languageModels[0]!;
 
 interface ChatContextType {
   // Chat state


### PR DESCRIPTION
   This PR adds the Horizon Alpha model to the OpenRouter models list, providing users with access to a powerful vision-capable model with 256k context length.
