### PR TITLE
Change deprecated Horizon Alpha model to new Horizon Beta model

### DIFF
--- a/src/ai/language/models/openrouter.ts
+++ b/src/ai/language/models/openrouter.ts
@@ -30,7 +30,6 @@ const openRouterModelData: Omit<LanguageModel, "provider">[] = [
     capabilities: [
       LanguageModelCapability.Vision,
       LanguageModelCapability.ToolCalling,
-      LanguageModelCapability.Reasoning,
       LanguageModelCapability.Pdf,
     ],
     bestFor: [


### PR DESCRIPTION
Horizon Alpha has now been deprecated, in favor of the new model, Horizon Beta.