### PR TITLE
Message editor shows blank content when editing messages in older chats or after refreshing the browser

### DIFF
--- a/src/app/_components/chat/messages/message.tsx
+++ b/src/app/_components/chat/messages/message.tsx
@@ -152,6 +152,7 @@ const PurePreviewMessage: React.FC<Props> = ({
                     key={key}
                     message={message}
                     setMode={setMode}
+                    chatId={chatId}
                   />
                 );
               }


### PR DESCRIPTION
Fixes message editor appearing blank when editing messages in older chats by adding proper chatId prop passing and content extraction from parts array.