### PR TITLE
fix: input overlay covering messages

### DIFF
--- a/src/app/(general)/_components/chat/chat.tsx
+++ b/src/app/(general)/_components/chat/chat.tsx
@@ -67,9 +67,11 @@ export const ChatContent = ({
           }}
           className={cn(
             "w-full px-4 pb-4",
-         
-            !hasMessages && !hasInitialMessages && "absolute bottom-4 left-1/2 max-w-3xl -translate-x-1/2",
-            (hasMessages || hasInitialMessages) && "mx-auto max-w-3xl"
+
+            !hasMessages &&
+              !hasInitialMessages &&
+              "absolute bottom-4 left-1/2 max-w-3xl -translate-x-1/2",
+            (hasMessages || hasInitialMessages) && "mx-auto max-w-3xl",
           )}
         >
           {/* Greeting - only shown when no messages */}

--- a/src/app/(general)/_components/chat/input/index.tsx
+++ b/src/app/(general)/_components/chat/input/index.tsx
@@ -77,10 +77,12 @@ const PureMultimodalInput: React.FC<Props> = ({
   const adjustHeight = () => {
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
-    
-      const maxHeight = Math.min(window.innerHeight * 0.35 - 32, textareaRef.current.scrollHeight + 2);
+
+      const maxHeight = Math.min(
+        window.innerHeight * 0.35 - 32,
+        textareaRef.current.scrollHeight + 2,
+      );
       if (textareaRef.current.scrollHeight + 2 <= maxHeight) {
-      
         textareaRef.current.style.height = `${textareaRef.current.scrollHeight + 2}px`;
         textareaRef.current.style.overflowY = "hidden";
       } else {

--- a/src/app/(general)/_components/chat/messages/index.tsx
+++ b/src/app/(general)/_components/chat/messages/index.tsx
@@ -50,7 +50,6 @@ const PureMessages: React.FC<Props> = ({
       ref={containerRef}
       className={cn(
         "relative flex h-full min-w-0 flex-1 flex-col gap-6 overflow-y-scroll py-8",
-       
       )}
     >
       {messages


### PR DESCRIPTION
Prevents textarea from overlaying previous messages when expanding by switching from absolute to flexible positioning and adding smart height limits with scrolling.


issue #204 