### PR TITLE
Feature request: Allow creation of new chats using query params #232

### DIFF
--- a/src/app/(general)/_components/chat/index.tsx
+++ b/src/app/(general)/_components/chat/index.tsx
@@ -17,6 +17,7 @@ interface Props {
   isReadonly: boolean;
   isNew: boolean;
   workbench?: Workbench;
+  prefillQuery?: string;
 }
 
 export const Chat = async ({
@@ -25,6 +26,7 @@ export const Chat = async ({
   isReadonly,
   isNew,
   workbench,
+  prefillQuery,
 }: Props) => {
   const initialMessages = isNew
     ? []
@@ -44,7 +46,7 @@ export const Chat = async ({
   const initialPreferences = {
     selectedChatModel: serverPreferences.selectedChatModel,
     imageGenerationModel: serverPreferences.imageGenerationModel,
-    useNativeSearch: serverPreferences.useNativeSearch,
+    useNativeSearch: prefillQuery ? true : serverPreferences.useNativeSearch, // Enable web search when query is provided
     toolkits: serverPreferences.toolkits
       ?.map((persistedToolkit: PersistedToolkit) => {
         const clientToolkit =
@@ -112,6 +114,7 @@ export const Chat = async ({
         initialVisibilityType={initialVisibilityType}
         autoResume={!isNew}
         workbench={workbench}
+        initialInput={prefillQuery}
         initialPreferences={initialPreferences}
       >
         <ChatContent

--- a/src/app/(general)/_components/chat/index.tsx
+++ b/src/app/(general)/_components/chat/index.tsx
@@ -18,6 +18,7 @@ interface Props {
   isNew: boolean;
   workbench?: Workbench;
   prefillQuery?: string;
+  autoSubmitQuery?: boolean;
 }
 
 export const Chat = async ({
@@ -27,6 +28,7 @@ export const Chat = async ({
   isNew,
   workbench,
   prefillQuery,
+  autoSubmitQuery,
 }: Props) => {
   const initialMessages = isNew
     ? []
@@ -115,6 +117,7 @@ export const Chat = async ({
         autoResume={!isNew}
         workbench={workbench}
         initialInput={prefillQuery}
+        autoSubmitInitialInput={autoSubmitQuery}
         initialPreferences={initialPreferences}
       >
         <ChatContent

--- a/src/app/(general)/_contexts/chat-context.tsx
+++ b/src/app/(general)/_contexts/chat-context.tsx
@@ -87,6 +87,7 @@ interface ChatProviderProps {
   initialVisibilityType: "public" | "private";
   autoResume: boolean;
   workbench?: Workbench;
+  initialInput?: string;
   initialPreferences?: {
     selectedChatModel?: LanguageModel;
     imageGenerationModel?: ImageModel;
@@ -102,6 +103,7 @@ export function ChatProvider({
   initialVisibilityType,
   autoResume,
   workbench,
+  initialInput,
   initialPreferences,
 }: ChatProviderProps) {
   const utils = api.useUtils();
@@ -222,6 +224,7 @@ export function ChatProvider({
   } = useChat({
     id,
     initialMessages,
+    initialInput,
     experimental_throttle: 100,
     sendExtraMessageFields: true,
     generateId: generateUUID,

--- a/src/app/(general)/_contexts/chat-context.tsx
+++ b/src/app/(general)/_contexts/chat-context.tsx
@@ -287,14 +287,14 @@ export function ChatProvider({
     onStreamError,
   });
 
-  const handleSubmit: UseChatHelpers["handleSubmit"] = (
-    event,
-    chatRequestOptions,
-  ) => {
-    // Reset stream stopped flag when submitting new message
-    setStreamStopped(false);
-    originalHandleSubmit(event, chatRequestOptions);
-  };
+  const handleSubmit: UseChatHelpers["handleSubmit"] = useCallback(
+    (event, chatRequestOptions) => {
+      // Reset stream stopped flag when submitting new message
+      setStreamStopped(false);
+      originalHandleSubmit(event, chatRequestOptions);
+    },
+    [originalHandleSubmit, setStreamStopped],
+  );
 
   useEffect(() => {
     if (
@@ -316,7 +316,7 @@ export function ChatProvider({
       messages.length === 0
     ) {
       const timer = setTimeout(() => {
-        handleSubmit(new Event("submit") as any);
+        handleSubmit();
       }, 100);
       return () => clearTimeout(timer);
     }

--- a/src/app/(general)/_contexts/chat-context.tsx
+++ b/src/app/(general)/_contexts/chat-context.tsx
@@ -88,6 +88,7 @@ interface ChatProviderProps {
   autoResume: boolean;
   workbench?: Workbench;
   initialInput?: string;
+  autoSubmitInitialInput?: boolean;
   initialPreferences?: {
     selectedChatModel?: LanguageModel;
     imageGenerationModel?: ImageModel;
@@ -104,6 +105,7 @@ export function ChatProvider({
   autoResume,
   workbench,
   initialInput,
+  autoSubmitInitialInput,
   initialPreferences,
 }: ChatProviderProps) {
   const utils = api.useUtils();
@@ -305,6 +307,26 @@ export function ChatProvider({
       setUseNativeSearch(false);
     }
   }, [selectedChatModel]);
+
+  useEffect(() => {
+    if (
+      autoSubmitInitialInput &&
+      initialInput &&
+      input === initialInput &&
+      messages.length === 0
+    ) {
+      const timer = setTimeout(() => {
+        handleSubmit(new Event("submit") as any);
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [
+    autoSubmitInitialInput,
+    initialInput,
+    input,
+    messages.length,
+    handleSubmit,
+  ]);
 
   const value = {
     messages,

--- a/src/app/(general)/new/page.tsx
+++ b/src/app/(general)/new/page.tsx
@@ -33,6 +33,7 @@ export default async function NewChatPage(props: NewChatPageProps) {
       isReadonly={false}
       isNew={true}
       prefillQuery={q}
+      autoSubmitQuery={q ? true : false}
     />
   );
 }

--- a/src/app/(general)/new/page.tsx
+++ b/src/app/(general)/new/page.tsx
@@ -1,24 +1,26 @@
-import { Chat } from "./_components/chat";
-import LandingPage from "./_components/landing-page";
+import { redirect } from "next/navigation";
 
+import { Chat } from "@/app/(general)/_components/chat";
 import { auth } from "@/server/auth";
-
 import { generateUUID } from "@/lib/utils";
 
-interface HomePageProps {
+interface NewChatPageProps {
   searchParams: Promise<{
     q?: string;
   }>;
 }
 
-export default async function Page(props: HomePageProps) {
+export default async function NewChatPage(props: NewChatPageProps) {
   const searchParams = await props.searchParams;
   const { q } = searchParams;
 
   const session = await auth();
 
   if (!session) {
-    return <LandingPage />;
+    const redirectUrl = q
+      ? `/login?redirect=${encodeURIComponent(`/new?q=${encodeURIComponent(q)}`)}`
+      : "/login?redirect=/new";
+    redirect(redirectUrl);
   }
 
   const id = generateUUID();


### PR DESCRIPTION
Implements the feature request from #232 to allow creation of new chats using query parameters.

### Usage
- `/new` - Creates a new empty chat
- `/new?q=What%20is%20React%3F` - Creates new chat with "What is React?" pre-filled and auto-executed


closes #232 