### PR TITLE
Fix/code block backticks

### DIFF
--- a/src/app/(general)/_components/chat/messages/utils/llm-code-block.tsx
+++ b/src/app/(general)/_components/chat/messages/utils/llm-code-block.tsx
@@ -13,5 +13,8 @@ export const LLMCodeBlock: LLMOutputComponent = ({ blockMatch }) => {
     return null;
   }
 
-  return <CodeBlock value={code} language={language as BundledLanguage} />;
+  // @llm-ui/code bug: failing to remove trailing backticks
+  const cleanedCode = code.replace(/```\s*$/, '').trim();
+
+  return <CodeBlock value={cleanedCode} language={language as BundledLanguage} />;
 };

--- a/src/app/(general)/_components/chat/messages/utils/llm-code-block.tsx
+++ b/src/app/(general)/_components/chat/messages/utils/llm-code-block.tsx
@@ -14,7 +14,9 @@ export const LLMCodeBlock: LLMOutputComponent = ({ blockMatch }) => {
   }
 
   // @llm-ui/code bug: failing to remove trailing backticks
-  const cleanedCode = code.replace(/```\s*$/, '').trim();
+  const cleanedCode = code.replace(/```\s*$/, "").trim();
 
-  return <CodeBlock value={cleanedCode} language={language as BundledLanguage} />;
+  return (
+    <CodeBlock value={cleanedCode} language={language as BundledLanguage} />
+  );
 };


### PR DESCRIPTION
I noticed the  trailing backticks (```) from code block  were not being stripped by the @llm-ui/code parser, causing them to appear in rendered code blocks. 