### PR TITLE
fix: improve markdown link visibility with better contrast color

### DIFF
--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -101,7 +101,7 @@ const NonMemoizedMarkdown: React.FC<MarkdownProps> = ({
           return (
             <Link
               href={href ?? ""}
-              className="text-primary underline"
+              className="underline text-[var(--color-primary-800)]"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -101,7 +101,7 @@ const NonMemoizedMarkdown: React.FC<MarkdownProps> = ({
           return (
             <Link
               href={href ?? ""}
-              className="underline text-[var(--color-primary-800)]"
+              className="text-[var(--color-primary-800)] underline"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
Before : 
<img width="903" height="96" alt="Screenshot 2025-08-17 095232" src="https://github.com/user-attachments/assets/3e8edcd7-6776-4e2b-b01a-4d685f9e7fa1" />

After : 
<img width="847" height="127" alt="Screenshot 2025-08-19 134125" src="https://github.com/user-attachments/assets/5885eecc-227b-4e10-a1f0-fb83ae35cc46" />
